### PR TITLE
Add base .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Rust build artifacts
+/target/
+**/*.rs.bk
+
+# Node dependencies and build output
+node_modules/
+# Yarn integrity and lock files are typically committed, but ignore debug logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# General build directories
+/dist/
+/build/
+
+# Test coverage
+/coverage/
+
+# Environment files
+.env


### PR DESCRIPTION
## Summary
- add standard Rust and Node ignores

## Testing
- `cargo test` *(fails: could not find `Cargo.toml`)*
- `npm test` *(fails: could not read `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_686bd8e0d51c83289d679b7de3068e33