### PR TITLE
Add CI workflow for Rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, work ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Format check
+        run: cargo fmt --check
+
+      - name: Clippy check
+        run: cargo clippy -- -D warnings
+
+      - name: Run tests
+        run: cargo test --all


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run formatting, linting and tests on Ubuntu, macOS and Windows
- cache Cargo registry and target directory to speed up CI

## Testing
- `cargo fmt --check` *(fails: rustfmt component not installed)*
- `cargo clippy -- -D warnings` *(fails: clippy component not installed)*
- `cargo test` *(fails: could not find `Cargo.toml`)*

------
https://chatgpt.com/codex/tasks/task_e_686bd998543c832880d768ff82dd4e12