### PR TITLE
Add GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug Report
+about: Create a bug report to help us improve MoQTail
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior. Provide a minimal reproducer if possible.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Logs**
+Attach relevant broker logs or CLI output.
+
+**Environment (please complete the following information):**
+- MoQTail version or commit:
+- Broker and version:
+- Rust version (if building from source):
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature Request
+about: Suggest an idea for MoQTail
+title: "[Feat] "
+labels: enhancement
+assignees: ''
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.
+
+*Tip: Start with a discussion; once fleshed out, open an RFC PR in `rfcs/`.*

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+## What & Why
+
+## How
+
+## Testing
+


### PR DESCRIPTION
## What & Why
- add issue templates for bug reports and feature requests
- add PR template so contributors describe changes

## How
- new `.github` directory with Markdown templates

## Testing
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_686bd9958b688328bc870dc61a537661