### PR TITLE
Add plugin scaffold with architecture README

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,29 @@
+# MoQTail Broker Plugins
+
+This directory contains broker-specific integration crates. Each subfolder
+implements the glue code needed to embed MoQTail's query engine into a
+particular MQTT broker.
+
+MoQTail is broker-agnostic at its core, but most brokers offer a plugin or
+extension API that lets us intercept publish/subscribe flows. Plugins compile the
+DSL to an efficient matcher and apply it server-side so that legacy clients see
+only standard MQTT traffic.
+
+```
+plugins/
+├── mosquitto/  # C-based loadable module written in Rust
+└── emqx/       # Rust NIF wrapping the Erlang extension API
+```
+
+The layout is intentionally similar across brokers:
+
+1. **`Cargo.toml`** – Rust crate manifest. Dependencies and build scripts vary per
+   broker.
+2. **`src/`** – Plugin entry points and any shim code bridging to the broker SDK.
+3. **`build.rs`** (optional) – Generates FFI bindings or performs extra steps.
+
+Each plugin is versioned independently but shares the core crates via the
+workspace in the repository root (coming in later milestones).
+
+> **Note:** The plugins are currently placeholders pending the v0.2 milestone.
+> Expect breaking changes as the APIs stabilise.

--- a/plugins/emqx/Cargo.toml
+++ b/plugins/emqx/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "moqtail-emqx"
+version = "0.0.0"
+edition = "2021"
+publish = false
+license = "MIT OR Apache-2.0"
+description = "Placeholder crate for the EMQX plugin"
+
+[lib]
+path = "src/lib.rs"
+crate-type = ["cdylib"]

--- a/plugins/emqx/src/lib.rs
+++ b/plugins/emqx/src/lib.rs
@@ -1,0 +1,4 @@
+//! EMQX plugin stub.
+
+#[no_mangle]
+pub extern "C" fn moqtail_init() {}

--- a/plugins/mosquitto/Cargo.toml
+++ b/plugins/mosquitto/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "moqtail-mosquitto"
+version = "0.0.0"
+edition = "2021"
+publish = false
+license = "MIT OR Apache-2.0"
+description = "Placeholder crate for the Mosquitto plugin"
+
+[lib]
+path = "src/lib.rs"
+crate-type = ["cdylib"]

--- a/plugins/mosquitto/src/lib.rs
+++ b/plugins/mosquitto/src/lib.rs
@@ -1,0 +1,4 @@
+//! Mosquitto plugin stub.
+
+#[no_mangle]
+pub extern "C" fn moqtail_init() {}


### PR DESCRIPTION
## Summary
- introduce `plugins/` directory and README outlining plugin structure
- add placeholder crates for Mosquitto and EMQX broker integrations

## Testing
- `cargo check --manifest-path plugins/mosquitto/Cargo.toml`
- `cargo check --manifest-path plugins/emqx/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_686bd993e86083289ca42c9d018ca624