### PR TITLE
Fix workspace Cargo.toml parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = [
-    "xtask"
+    "xtask",
     "crates/moqtail-core",
     "crates/moqtail-cli",
 ]


### PR DESCRIPTION
## Summary
- add missing comma after `xtask` in workspace members list
- run `cargo check` (fails: duplicate key in Cargo.lock)

## Testing
- `cargo check` *(fails: duplicate key in Cargo.lock)*

------
https://chatgpt.com/codex/tasks/task_e_686bdc3f395083288c4ad7a2c11a1868