### PR TITLE
Fix workspace & improve repo-graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,8 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
 name = "moqtail-cli"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = [
-    "xtask"
+    "xtask",
     "crates/moqtail-core",
     "crates/moqtail-cli",
 ]

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -1,0 +1,16 @@
+# xtask
+
+This crate contains small developer utilities used while working on MoQTail.
+
+## Running
+
+Invoke commands from the workspace root with `cargo run`:
+
+```bash
+cargo run -p xtask -- <command>
+```
+
+### Commands
+
+- `repo-graph` – print dependency edges between crates in this workspace.
+  External dependencies are filtered out so only workspace relationships are shown.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use cargo_metadata::{MetadataCommand, PackageId};
@@ -28,10 +28,23 @@ fn repo_graph() -> Result<()> {
     let metadata = MetadataCommand::new().exec()?;
     let workspace: HashSet<PackageId> = metadata.workspace_members.into_iter().collect();
 
-    for package in metadata.packages {
-        if workspace.contains(&package.id) {
-            for dep in package.dependencies {
-                println!("{} -> {}", package.name, dep.name);
+    let resolve = metadata.resolve.expect("resolve graph missing");
+    let id_to_name: HashMap<PackageId, String> = metadata
+        .packages
+        .iter()
+        .map(|p| (p.id.clone(), p.name.clone()))
+        .collect();
+
+    for node in resolve.nodes {
+        if workspace.contains(&node.id) {
+            for dep_id in node.dependencies {
+                if workspace.contains(&dep_id) {
+                    println!(
+                        "{} -> {}",
+                        id_to_name.get(&node.id).unwrap(),
+                        id_to_name.get(&dep_id).unwrap()
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- fix workspace member list
- filter repo-graph output to only show workspace edges
- document xtask usage

## Testing
- `cargo check`
- `cargo run -p xtask -- repo-graph`

------
https://chatgpt.com/codex/tasks/task_e_686bdc40cdac8328a31d81cf7950598f