### PR TITLE
Implement minimal selector parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "camino"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,8 +96,14 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "clap"
@@ -137,6 +152,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,10 +209,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "libc"
+version = "0.2.174"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
 name = "moqtail-cli"
 version = "0.1.0"
 dependencies = [
@@ -169,12 +231,60 @@ dependencies = [
 [[package]]
 name = "moqtail-core"
 version = "0.1.0"
+dependencies = [
+ "pest",
+ "pest_derive",
+]
 
 [[package]]
 name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "pest"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
+dependencies = [
+ "memchr",
+ "thiserror 2.0.12",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
+dependencies = [
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -242,6 +352,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,7 +385,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -279,6 +409,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,6 +442,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = [
-    "xtask"
+    "xtask",
     "crates/moqtail-core",
     "crates/moqtail-cli",
 ]

--- a/crates/moqtail-core/Cargo.toml
+++ b/crates/moqtail-core/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+pest = "2"
+pest_derive = "2"
+

--- a/crates/moqtail-core/src/ast.rs
+++ b/crates/moqtail-core/src/ast.rs
@@ -1,0 +1,21 @@
+#[derive(Debug, PartialEq, Eq)]
+pub enum Axis {
+    Child,
+    Descendant,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Segment {
+    Literal(String),
+    Plus,
+    Hash,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Step {
+    pub axis: Axis,
+    pub segment: Segment,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Selector(pub Vec<Step>);

--- a/crates/moqtail-core/src/lib.rs
+++ b/crates/moqtail-core/src/lib.rs
@@ -1,5 +1,29 @@
 //! Core library for MoQtail
 
+pub mod ast;
+mod parser;
+
+pub use parser::compile;
+
 pub fn hello() -> &'static str {
     "Hello, MoQtail!"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_selectors() {
+        assert!(compile("/foo/bar").is_ok());
+        assert!(compile("//sensor").is_ok());
+        assert!(compile("/+/#").is_ok());
+    }
+
+    #[test]
+    fn invalid_selectors() {
+        assert!(compile("foo/bar").is_err());
+        assert!(compile("/foo//").is_err());
+        assert!(compile("/fo$" ).is_err());
+    }
 }

--- a/crates/moqtail-core/src/parser.rs
+++ b/crates/moqtail-core/src/parser.rs
@@ -1,0 +1,45 @@
+use pest::Parser;
+use pest_derive::Parser;
+
+use crate::ast::{Axis, Segment, Step, Selector};
+
+#[derive(Parser)]
+#[grammar = "selector.pest"]
+struct SelectorParser;
+
+pub fn compile(input: &str) -> Result<Selector, String> {
+    let mut pairs = SelectorParser::parse(Rule::selector, input)
+        .map_err(|e| e.to_string())?;
+    let pair = pairs.next().unwrap();
+    let mut steps = Vec::new();
+
+    for seg in pair.into_inner() {
+        if seg.as_rule() != Rule::path_segment {
+            continue;
+        }
+        let mut inner = seg.into_inner();
+        let axis_pair = inner.next().unwrap();
+        let segment_pair = inner.next().unwrap();
+        let segment_inner = segment_pair.into_inner().next().unwrap();
+
+        let axis = match axis_pair.as_str() {
+            "/" => Axis::Child,
+            "//" => Axis::Descendant,
+            _ => unreachable!(),
+        };
+
+        let segment = match segment_inner.as_rule() {
+            Rule::wildcard => match segment_inner.as_str() {
+                "+" => Segment::Plus,
+                "#" => Segment::Hash,
+                _ => unreachable!(),
+            },
+            Rule::ident => Segment::Literal(segment_inner.as_str().to_string()),
+            _ => unreachable!(),
+        };
+
+        steps.push(Step { axis, segment });
+    }
+
+    Ok(Selector(steps))
+}

--- a/crates/moqtail-core/src/selector.pest
+++ b/crates/moqtail-core/src/selector.pest
@@ -1,0 +1,13 @@
+WHITESPACE = _{ " " | "\t" }
+
+selector = { SOI ~ path_segment+ ~ EOI }
+
+path_segment = { slash ~ segment }
+
+slash = { "//" | "/" }
+
+segment = { wildcard | ident }
+
+wildcard = { "+" | "#" }
+
+ident = { (ASCII_ALPHANUMERIC | "_" | "-")+ }


### PR DESCRIPTION
## Summary
- add `ast` and `parser` modules to `moqtail-core`
- parse selectors using a new pest grammar
- expose a `compile` function
- test valid and invalid selector cases

## Testing
- `cargo test -q`

------
https://chatgpt.com/codex/tasks/task_e_686bdc40d41883288f0f629069ec1343