### PR TITLE
Add initial Mosquitto plugin skeleton

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = [
-    "xtask"
+    "xtask",
     "crates/moqtail-core",
     "crates/moqtail-cli",
 ]

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -27,3 +27,14 @@ workspace in the repository root (coming in later milestones).
 
 > **Note:** The plugins are currently placeholders pending the v0.2 milestone.
 > Expect breaking changes as the APIs stabilise.
+
+## Building the Mosquitto plugin
+
+Compile the shared library using Cargo:
+
+```bash
+$ cargo build -p moqtail-mosquitto --release
+```
+
+The resulting `libmoqtail_mosquitto.so` in `target/release/` can then be loaded
+by Mosquitto as a plugin.

--- a/plugins/mosquitto/Cargo.toml
+++ b/plugins/mosquitto/Cargo.toml
@@ -9,3 +9,11 @@ description = "Placeholder crate for the Mosquitto plugin"
 [lib]
 path = "src/lib.rs"
 crate-type = ["cdylib"]
+
+[workspace]
+
+[dependencies]
+moqtail-core = { path = "../../crates/moqtail-core" }
+
+[build-dependencies]
+cc = "1"

--- a/plugins/mosquitto/build.rs
+++ b/plugins/mosquitto/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!("cargo:rerun-if-changed=src/dummy.c");
+    cc::Build::new()
+        .file("src/dummy.c")
+        .compile("moqtail_mosquitto_dummy");
+}

--- a/plugins/mosquitto/src/dummy.c
+++ b/plugins/mosquitto/src/dummy.c
@@ -1,0 +1,4 @@
+#ifdef _WIN32
+__declspec(dllexport)
+#endif
+void moqtail_dummy(void) {}

--- a/plugins/mosquitto/src/lib.rs
+++ b/plugins/mosquitto/src/lib.rs
@@ -1,4 +1,37 @@
-//! Mosquitto plugin stub.
+//! Mosquitto plugin entry points.
+//!
+//! This minimal implementation demonstrates how a Mosquitto plugin written in
+//! Rust can expose the C symbols expected by the broker. The functions here
+//! simply log messages using the `moqtail-core` crate.
 
+use moqtail_core::hello;
+use std::os::raw::{c_char, c_int, c_void};
+
+#[repr(C)]
+pub struct MosquittoOpt {
+    pub key: *const c_char,
+    pub value: *const c_char,
+}
+
+/// Called when the plugin is loaded.
 #[no_mangle]
-pub extern "C" fn moqtail_init() {}
+pub unsafe extern "C" fn mosquitto_plugin_init(
+    _identifier: *mut c_void,
+    _userdata: *mut *mut c_void,
+    _options: *mut MosquittoOpt,
+    _option_count: c_int,
+) -> c_int {
+    println!("[MoQTail] init: {}", hello());
+    0
+}
+
+/// Called when the plugin is unloaded.
+#[no_mangle]
+pub unsafe extern "C" fn mosquitto_plugin_cleanup(
+    _userdata: *mut c_void,
+    _options: *mut MosquittoOpt,
+    _option_count: c_int,
+) -> c_int {
+    println!("[MoQTail] cleanup");
+    0
+}


### PR DESCRIPTION
## Summary
- flesh out mosquitto plugin with init and cleanup FFI
- build dummy C shim during compilation
- document building the plugin
- fix workspace manifest so cargo works

## Testing
- `cargo check --manifest-path plugins/mosquitto/Cargo.toml`
- `cargo test --manifest-path plugins/mosquitto/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_686bdc417c7c8328b58780fb22dd9afa