### PR TITLE
Add MQTT sub command enhancements

### DIFF
--- a/crates/moqtail-cli/Cargo.toml
+++ b/crates/moqtail-cli/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 moqtail-core = { path = "../moqtail-core" }
+rumqttc = "0.24"
 
 [dependencies.clap]
 version = "4"

--- a/crates/moqtail-cli/src/main.rs
+++ b/crates/moqtail-cli/src/main.rs
@@ -1,5 +1,7 @@
 use clap::{Parser, Subcommand};
-use moqtail_core::{compile};
+use moqtail_core::compile;
+use rumqttc::{Client, Event, Incoming, MqttOptions, QoS};
+use std::time::Duration;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -22,8 +24,37 @@ fn main() {
 
     match cli.command {
         Commands::Sub { query } => {
-            let out = compile(&query);
-            println!("{}", out);
+            match compile(&query) {
+                Ok(selector) => {
+                    println!("{}", selector);
+                    if std::env::var("MOQTAIL_DRY_RUN").is_ok() {
+                        return;
+                    }
+
+                    let mut mqttoptions =
+                        MqttOptions::new("moqtail-cli", "localhost", 1883);
+                    mqttoptions.set_keep_alive(Duration::from_secs(5));
+
+                    let (mut client, mut connection) = Client::new(mqttoptions, 10);
+                    client
+                        .subscribe(selector.to_string(), QoS::AtMostOnce)
+                        .unwrap();
+
+                    for notification in connection.iter() {
+                        if let Event::Incoming(Incoming::Publish(p)) = notification {
+                            println!(
+                                "{}: {}",
+                                p.topic,
+                                String::from_utf8_lossy(&p.payload)
+                            );
+                        }
+                    }
+                }
+                Err(e) => {
+                    eprintln!("Failed to compile selector: {}", e);
+                    std::process::exit(1);
+                }
+            }
         }
     }
 }

--- a/crates/moqtail-cli/tests/cli.rs
+++ b/crates/moqtail-cli/tests/cli.rs
@@ -4,8 +4,17 @@ use predicates::str::contains;
 #[test]
 fn subprints_compiled_selector() {
     let mut cmd = Command::cargo_bin("moqtail-cli").unwrap();
-    cmd.arg("sub").arg("foo");
+    cmd.arg("sub").arg("/foo").env("MOQTAIL_DRY_RUN", "1");
     cmd.assert()
         .success()
-        .stdout(contains("compiled: foo"));
+        .stdout(contains("/foo"));
+}
+
+#[test]
+fn sub_errors_on_invalid_selector() {
+    let mut cmd = Command::cargo_bin("moqtail-cli").unwrap();
+    cmd.arg("sub").arg("foo").env("MOQTAIL_DRY_RUN", "1");
+    cmd.assert()
+        .failure()
+        .stderr(contains("Failed to compile selector"));
 }

--- a/crates/moqtail-core/src/ast.rs
+++ b/crates/moqtail-core/src/ast.rs
@@ -19,3 +19,23 @@ pub struct Step {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Selector(pub Vec<Step>);
+
+use std::fmt;
+
+impl fmt::Display for Selector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for step in &self.0 {
+            match step.axis {
+                Axis::Child => write!(f, "/")?,
+                Axis::Descendant => write!(f, "//")?,
+            }
+
+            match &step.segment {
+                Segment::Literal(s) => write!(f, "{}", s)?,
+                Segment::Plus => write!(f, "+")?,
+                Segment::Hash => write!(f, "#")?,
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- handle `Result<Selector, String>` from `compile` in CLI
- add MQTT integration with rumqttc
- display selectors cleanly
- extend CLI tests for error cases

## Testing
- `cargo test -q` *(fails: failed to parse lock file)*

------
https://chatgpt.com/codex/tasks/task_e_686be10549808328bc3ab57182b8277c