### PR TITLE
Add predicate parsing

### DIFF
--- a/crates/moqtail-core/src/ast.rs
+++ b/crates/moqtail-core/src/ast.rs
@@ -12,9 +12,15 @@ pub enum Segment {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+pub enum Predicate {
+    Equals { name: String, value: String },
+}
+
+#[derive(Debug, PartialEq, Eq)]
 pub struct Step {
     pub axis: Axis,
     pub segment: Segment,
+    pub predicates: Vec<Predicate>,
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/crates/moqtail-core/src/lib.rs
+++ b/crates/moqtail-core/src/lib.rs
@@ -9,7 +9,6 @@ pub fn hello() -> &'static str {
     "Hello, MoQtail!"
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -25,13 +24,14 @@ mod tests {
     fn invalid_selectors() {
         assert!(compile("foo/bar").is_err());
         assert!(compile("/foo//").is_err());
-        assert!(compile("/fo$" ).is_err());
+        assert!(compile("/fo$").is_err());
     }
 
-/// Placeholder compile function until the real parser exists.
-///
-/// Takes a query string and returns a representation of the compiled
-/// selector. For now this simply prefixes the query with `"compiled: "`.
-pub fn compile(query: &str) -> String {
-    format!("compiled: {}", query)
+    /// Placeholder compile function until the real parser exists.
+    ///
+    /// Takes a query string and returns a representation of the compiled
+    /// selector. For now this simply prefixes the query with `"compiled: "`.
+    pub fn compile(query: &str) -> String {
+        format!("compiled: {}", query)
+    }
 }

--- a/crates/moqtail-core/src/parser.rs
+++ b/crates/moqtail-core/src/parser.rs
@@ -1,15 +1,14 @@
 use pest::Parser;
 use pest_derive::Parser;
 
-use crate::ast::{Axis, Segment, Step, Selector};
+use crate::ast::{Axis, Predicate, Segment, Selector, Step};
 
 #[derive(Parser)]
 #[grammar = "selector.pest"]
 struct SelectorParser;
 
 pub fn compile(input: &str) -> Result<Selector, String> {
-    let mut pairs = SelectorParser::parse(Rule::selector, input)
-        .map_err(|e| e.to_string())?;
+    let mut pairs = SelectorParser::parse(Rule::selector, input).map_err(|e| e.to_string())?;
     let pair = pairs.next().unwrap();
     let mut steps = Vec::new();
 
@@ -38,7 +37,22 @@ pub fn compile(input: &str) -> Result<Selector, String> {
             _ => unreachable!(),
         };
 
-        steps.push(Step { axis, segment });
+        let mut predicates = Vec::new();
+        for pred_pair in inner {
+            if pred_pair.as_rule() != Rule::predicate {
+                continue;
+            }
+            let mut pred_inner = pred_pair.into_inner();
+            let name = pred_inner.next().unwrap().as_str().to_string();
+            let value = pred_inner.next().unwrap().as_str().to_string();
+            predicates.push(Predicate::Equals { name, value });
+        }
+
+        steps.push(Step {
+            axis,
+            segment,
+            predicates,
+        });
     }
 
     Ok(Selector(steps))

--- a/crates/moqtail-core/src/selector.pest
+++ b/crates/moqtail-core/src/selector.pest
@@ -2,12 +2,16 @@ WHITESPACE = _{ " " | "\t" }
 
 selector = { SOI ~ path_segment+ ~ EOI }
 
-path_segment = { slash ~ segment }
+path_segment = { slash ~ segment ~ predicate* }
 
 slash = { "//" | "/" }
 
 segment = { wildcard | ident }
 
+predicate = { "[" ~ ident ~ "=" ~ number ~ "]" }
+
 wildcard = { "+" | "#" }
 
 ident = { (ASCII_ALPHANUMERIC | "_" | "-")+ }
+
+number = { ASCII_DIGIT+ }

--- a/crates/moqtail-core/tests/selector.rs
+++ b/crates/moqtail-core/tests/selector.rs
@@ -1,0 +1,20 @@
+use moqtail_core::{
+    ast::{Axis, Predicate, Segment, Selector, Step},
+    compile,
+};
+
+#[test]
+fn parse_selector_with_predicate() {
+    let sel = compile("/foo[bar=1]").unwrap();
+    assert_eq!(
+        sel,
+        Selector(vec![Step {
+            axis: Axis::Child,
+            segment: Segment::Literal("foo".into()),
+            predicates: vec![Predicate::Equals {
+                name: "bar".into(),
+                value: "1".into()
+            }],
+        }])
+    );
+}


### PR DESCRIPTION
## Summary
- add a `Predicate` enum and store predicates in `Step`
- allow predicates `[name=value]` in grammar
- parse predicates in the selector parser
- test parsing of `/foo[bar=1]`
- close the tests module in `lib.rs`

## Testing
- `cargo test --all --quiet` *(fails: failed to parse lock file)*

------
https://chatgpt.com/codex/tasks/task_e_686be103a5d48328ab343cbcbbee65fa