### PR TITLE
Add topic matcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,14 +68,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
-
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-
 name = "assert_cmd"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,6 +88,15 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bstr"
@@ -212,6 +213,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,21 +227,6 @@ dependencies = [
  "block-buffer",
  "crypto-common",
 ]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-
-[[package]]
-name = "difflib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "doc-comment"
@@ -255,6 +247,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -377,7 +379,9 @@ checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
 dependencies = [
  "pest",
  "sha2",
-=======
+]
+
+[[package]]
 name = "predicates"
 version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/moqtail-cli/src/main.rs
+++ b/crates/moqtail-cli/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use moqtail_core::{compile};
+use moqtail_core::compile;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -21,9 +21,12 @@ fn main() {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Sub { query } => {
-            let out = compile(&query);
-            println!("{}", out);
-        }
+        Commands::Sub { query } => match compile(&query) {
+            Ok(sel) => println!("{:?}", sel),
+            Err(e) => {
+                eprintln!("{}", e);
+                std::process::exit(1);
+            }
+        },
     }
 }

--- a/crates/moqtail-cli/tests/cli.rs
+++ b/crates/moqtail-cli/tests/cli.rs
@@ -4,8 +4,6 @@ use predicates::str::contains;
 #[test]
 fn subprints_compiled_selector() {
     let mut cmd = Command::cargo_bin("moqtail-cli").unwrap();
-    cmd.arg("sub").arg("foo");
-    cmd.assert()
-        .success()
-        .stdout(contains("compiled: foo"));
+    cmd.arg("sub").arg("/foo");
+    cmd.assert().success().stdout(contains("Selector"));
 }

--- a/crates/moqtail-core/src/lib.rs
+++ b/crates/moqtail-core/src/lib.rs
@@ -1,14 +1,15 @@
 //! Core library for MoQtail
 
 pub mod ast;
+mod matcher;
 mod parser;
 
+pub use matcher::Matcher;
 pub use parser::compile;
 
 pub fn hello() -> &'static str {
     "Hello, MoQtail!"
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -25,13 +26,6 @@ mod tests {
     fn invalid_selectors() {
         assert!(compile("foo/bar").is_err());
         assert!(compile("/foo//").is_err());
-        assert!(compile("/fo$" ).is_err());
+        assert!(compile("/fo$").is_err());
     }
-
-/// Placeholder compile function until the real parser exists.
-///
-/// Takes a query string and returns a representation of the compiled
-/// selector. For now this simply prefixes the query with `"compiled: "`.
-pub fn compile(query: &str) -> String {
-    format!("compiled: {}", query)
 }

--- a/crates/moqtail-core/src/matcher.rs
+++ b/crates/moqtail-core/src/matcher.rs
@@ -1,0 +1,116 @@
+use crate::ast::{Axis, Segment, Selector, Step};
+
+pub struct Matcher {
+    selector: Selector,
+}
+
+impl Matcher {
+    pub fn new(selector: Selector) -> Self {
+        Self { selector }
+    }
+
+    pub fn matches(&self, topic: &str) -> bool {
+        let segments: Vec<&str> = if topic.is_empty() {
+            Vec::new()
+        } else {
+            topic.split('/').collect()
+        };
+        Self::match_steps(&self.selector.0, &segments)
+    }
+
+    fn match_steps(steps: &[Step], topic: &[&str]) -> bool {
+        if steps.is_empty() {
+            return topic.is_empty();
+        }
+        let step = &steps[0];
+        match step.axis {
+            Axis::Child => Self::match_child(step, &steps[1..], topic),
+            Axis::Descendant => {
+                // try to match at current or any subsequent position
+                for idx in 0..=topic.len() {
+                    if Self::match_child(step, &steps[1..], &topic[idx..]) {
+                        return true;
+                    }
+                    if idx == topic.len() {
+                        break;
+                    }
+                }
+                false
+            }
+        }
+    }
+
+    fn match_child(step: &Step, rest: &[Step], topic: &[&str]) -> bool {
+        match step.segment {
+            Segment::Literal(ref lit) => {
+                if let Some((first, rest_topic)) = topic.split_first() {
+                    if lit == first {
+                        Self::match_steps(rest, rest_topic)
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            }
+            Segment::Plus => {
+                if let Some((_first, rest_topic)) = topic.split_first() {
+                    Self::match_steps(rest, rest_topic)
+                } else {
+                    false
+                }
+            }
+            Segment::Hash => {
+                // Try zero or more segments
+                if Self::match_steps(rest, topic) {
+                    return true;
+                }
+                for idx in 0..topic.len() {
+                    if Self::match_steps(rest, &topic[idx + 1..]) {
+                        return true;
+                    }
+                }
+                false
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::compile;
+
+    #[test]
+    fn simple_match() {
+        let sel = compile("/foo/bar").unwrap();
+        let m = Matcher::new(sel);
+        assert!(m.matches("foo/bar"));
+        assert!(!m.matches("foo/baz"));
+    }
+
+    #[test]
+    fn plus_wildcard() {
+        let sel = compile("/foo/+").unwrap();
+        let m = Matcher::new(sel);
+        assert!(m.matches("foo/bar"));
+        assert!(m.matches("foo/baz"));
+        assert!(!m.matches("foo"));
+    }
+
+    #[test]
+    fn hash_wildcard() {
+        let sel = compile("/foo/#").unwrap();
+        let m = Matcher::new(sel);
+        assert!(m.matches("foo"));
+        assert!(m.matches("foo/bar/baz"));
+    }
+
+    #[test]
+    fn descendant_axis() {
+        let sel = compile("//sensor").unwrap();
+        let m = Matcher::new(sel);
+        assert!(m.matches("building/floor/sensor"));
+        assert!(!m.matches("building/floor/actuator"));
+    }
+}


### PR DESCRIPTION
## Summary
- implement `Matcher` struct in a new `matcher.rs`
- export `Matcher` from moqtail-core
- update CLI to print parsed selector
- adjust CLI tests
- regenerate `Cargo.lock`

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686be10474048328919b514706a301b6