### PR TITLE
Add Mosquitto plugin filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,14 +68,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
-
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-
 name = "assert_cmd"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,6 +88,15 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bstr"
@@ -212,6 +213,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,21 +227,6 @@ dependencies = [
  "block-buffer",
  "crypto-common",
 ]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-
-[[package]]
-name = "difflib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "doc-comment"
@@ -255,6 +247,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -377,7 +379,9 @@ checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
 dependencies = [
  "pest",
  "sha2",
-=======
+]
+
+[[package]]
 name = "predicates"
 version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/moqtail-core/src/lib.rs
+++ b/crates/moqtail-core/src/lib.rs
@@ -35,3 +35,5 @@ mod tests {
 pub fn compile(query: &str) -> String {
     format!("compiled: {}", query)
 }
+
+}

--- a/plugins/mosquitto/README.md
+++ b/plugins/mosquitto/README.md
@@ -1,0 +1,22 @@
+# MoQTail Mosquitto Plugin
+
+This plugin integrates the MoQTail selector engine into the Mosquitto broker. It parses one or more `plugin_opt_selector` options and filters publish events before they reach subscribing clients.
+
+## Building
+
+```bash
+$ cargo build --manifest-path plugins/mosquitto/Cargo.toml --release
+```
+
+The resulting `libmoqtail_mosquitto.so` can be loaded by Mosquitto.
+
+## Example Configuration
+
+```conf
+# mosquitto.conf
+plugin /path/to/libmoqtail_mosquitto.so
+plugin_opt_selector /foo/+
+plugin_opt_selector //sensor/#
+```
+
+Each `plugin_opt_selector` entry is compiled using `moqtail-core`. Messages that do not match any selector are dropped before being routed to clients.

--- a/plugins/mosquitto/src/lib.rs
+++ b/plugins/mosquitto/src/lib.rs
@@ -1,11 +1,124 @@
 //! Mosquitto plugin entry points.
 //!
-//! This minimal implementation demonstrates how a Mosquitto plugin written in
-//! Rust can expose the C symbols expected by the broker. The functions here
-//! simply log messages using the `moqtail-core` crate.
+//! The plugin parses `plugin_opt_selector` entries from the broker
+//! configuration, compiles them using `moqtail-core`, and registers a publish
+//! callback.  Incoming messages are filtered before they reach the broker
+//! clients.
 
-use moqtail_core::hello;
-use std::os::raw::{c_char, c_int, c_void};
+use moqtail_core::{ast::{Axis, Segment, Selector, Step}, compile};
+use std::{ffi::CStr, os::raw::{c_char, c_int, c_void}};
+
+const MOSQ_EVT_MESSAGE: c_int = 7;
+const MOSQ_ERR_SUCCESS: c_int = 0;
+
+#[repr(C)]
+pub struct MosquittoEvtMessage {
+    _future: *mut c_void,
+    _client: *mut c_void,
+    topic: *mut c_char,
+    _payload: *mut c_void,
+    _properties: *mut c_void,
+    _reason_string: *mut c_char,
+    _payloadlen: u32,
+    _qos: u8,
+    _reason_code: u8,
+    _retain: bool,
+}
+
+extern "C" {
+    #[cfg_attr(not(test), link_name = "mosquitto_callback_register")]
+    fn mosquitto_callback_register(
+        identifier: *mut c_void,
+        event: c_int,
+        cb_func: Option<extern "C" fn(c_int, *mut c_void, *mut c_void) -> c_int>,
+        event_data: *const c_void,
+        userdata: *mut c_void,
+    ) -> c_int;
+
+    #[cfg_attr(not(test), link_name = "mosquitto_callback_unregister")]
+    fn mosquitto_callback_unregister(
+        identifier: *mut c_void,
+        event: c_int,
+        cb_func: Option<extern "C" fn(c_int, *mut c_void, *mut c_void) -> c_int>,
+        event_data: *const c_void,
+    ) -> c_int;
+}
+
+pub struct PluginContext {
+    selectors: Vec<Selector>,
+}
+
+fn match_segment(seg: &Segment, value: &str) -> bool {
+    match seg {
+        Segment::Literal(lit) => lit == value,
+        Segment::Plus => true,
+        Segment::Hash => true,
+    }
+}
+
+fn match_steps(steps: &[Step], segments: &[&str]) -> bool {
+    if steps.is_empty() {
+        return segments.is_empty();
+    }
+
+    let step = &steps[0];
+
+    if matches!(step.segment, Segment::Hash) {
+        return true;
+    }
+
+    match step.axis {
+        Axis::Child => {
+            if segments.is_empty() {
+                return false;
+            }
+            if match_segment(&step.segment, segments[0]) {
+                match_steps(&steps[1..], &segments[1..])
+            } else {
+                false
+            }
+        }
+        Axis::Descendant => {
+            for i in 0..segments.len() {
+                if match_segment(&step.segment, segments[i])
+                    && match_steps(&steps[1..], &segments[i + 1..])
+                {
+                    return true;
+                }
+            }
+            false
+        }
+    }
+}
+
+fn matches_selector(sel: &Selector, topic: &str) -> bool {
+    let parts: Vec<&str> = if topic.is_empty() {
+        Vec::new()
+    } else {
+        topic.split('/').collect()
+    };
+    match_steps(&sel.0, &parts)
+}
+
+extern "C" fn on_message(_: c_int, event_data: *mut c_void, userdata: *mut c_void) -> c_int {
+    unsafe {
+        let ctx = &*(userdata as *mut PluginContext);
+        let msg = &*(event_data as *mut MosquittoEvtMessage);
+        if msg.topic.is_null() {
+            return MOSQ_ERR_SUCCESS;
+        }
+        let topic = match CStr::from_ptr(msg.topic).to_str() {
+            Ok(t) => t,
+            Err(_) => return 1,
+        };
+        for sel in &ctx.selectors {
+            if matches_selector(sel, topic) {
+                return MOSQ_ERR_SUCCESS;
+            }
+        }
+    }
+    1
+}
 
 #[repr(C)]
 pub struct MosquittoOpt {
@@ -16,22 +129,121 @@ pub struct MosquittoOpt {
 /// Called when the plugin is loaded.
 #[no_mangle]
 pub unsafe extern "C" fn mosquitto_plugin_init(
-    _identifier: *mut c_void,
-    _userdata: *mut *mut c_void,
-    _options: *mut MosquittoOpt,
-    _option_count: c_int,
+    identifier: *mut c_void,
+    userdata: *mut *mut c_void,
+    options: *mut MosquittoOpt,
+    option_count: c_int,
 ) -> c_int {
-    println!("[MoQTail] init: {}", hello());
-    0
+    let slice = std::slice::from_raw_parts(options, option_count as usize);
+    let mut selectors = Vec::new();
+
+    for opt in slice.iter() {
+        if opt.key.is_null() || opt.value.is_null() {
+            continue;
+        }
+        let key = CStr::from_ptr(opt.key).to_string_lossy();
+        if key == "selector" {
+            let val = CStr::from_ptr(opt.value).to_string_lossy();
+            match compile(&val) {
+                Ok(sel) => selectors.push(sel),
+                Err(e) => eprintln!("[MoQTail] selector error: {}", e),
+            }
+        }
+    }
+
+    let ctx = Box::new(PluginContext { selectors });
+    let ctx_ptr = Box::into_raw(ctx) as *mut c_void;
+    *userdata = ctx_ptr;
+
+    mosquitto_callback_register(
+        identifier,
+        MOSQ_EVT_MESSAGE,
+        Some(on_message),
+        std::ptr::null(),
+        ctx_ptr,
+    )
 }
 
 /// Called when the plugin is unloaded.
 #[no_mangle]
 pub unsafe extern "C" fn mosquitto_plugin_cleanup(
-    _userdata: *mut c_void,
+    identifier: *mut c_void,
+    userdata: *mut c_void,
     _options: *mut MosquittoOpt,
     _option_count: c_int,
 ) -> c_int {
-    println!("[MoQTail] cleanup");
-    0
+    let _ = mosquitto_callback_unregister(identifier, MOSQ_EVT_MESSAGE, Some(on_message), std::ptr::null());
+    if !userdata.is_null() {
+        drop(Box::from_raw(userdata as *mut PluginContext));
+    }
+    MOSQ_ERR_SUCCESS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    static mut REGISTERED: Option<(extern "C" fn(c_int, *mut c_void, *mut c_void) -> c_int, *mut c_void)> = None;
+
+    #[no_mangle]
+    unsafe extern "C" fn mosquitto_callback_register(
+        _identifier: *mut c_void,
+        _event: c_int,
+        cb_func: Option<extern "C" fn(c_int, *mut c_void, *mut c_void) -> c_int>,
+        _event_data: *const c_void,
+        userdata: *mut c_void,
+    ) -> c_int {
+        if let Some(f) = cb_func {
+            REGISTERED = Some((f, userdata));
+        }
+        MOSQ_ERR_SUCCESS
+    }
+
+    #[no_mangle]
+    unsafe extern "C" fn mosquitto_callback_unregister(
+        _identifier: *mut c_void,
+        _event: c_int,
+        _cb_func: Option<extern "C" fn(c_int, *mut c_void, *mut c_void) -> c_int>,
+        _event_data: *const c_void,
+    ) -> c_int {
+        REGISTERED = None;
+        MOSQ_ERR_SUCCESS
+    }
+
+    #[test]
+    fn filter_logic() {
+        unsafe {
+            let key = CString::new("selector").unwrap();
+            let val = CString::new("/foo/+" ).unwrap();
+            let mut opt = MosquittoOpt { key: key.as_ptr(), value: val.as_ptr() };
+            let mut userdata: *mut c_void = std::ptr::null_mut();
+
+            assert_eq!(mosquitto_plugin_init(std::ptr::null_mut(), &mut userdata, &mut opt, 1), MOSQ_ERR_SUCCESS);
+            let (cb, ctx) = REGISTERED.expect("callback registered");
+
+            let topic1 = CString::new("foo/bar").unwrap();
+            let mut msg = MosquittoEvtMessage {
+                _future: std::ptr::null_mut(),
+                _client: std::ptr::null_mut(),
+                topic: topic1.as_ptr() as *mut c_char,
+                _payload: std::ptr::null_mut(),
+                _properties: std::ptr::null_mut(),
+                _reason_string: std::ptr::null_mut(),
+                _payloadlen: 0,
+                _qos: 0,
+                _reason_code: 0,
+                _retain: false,
+            };
+
+            assert_eq!(cb(MOSQ_EVT_MESSAGE, &mut msg as *mut _ as *mut c_void, ctx), MOSQ_ERR_SUCCESS);
+
+            let topic2 = CString::new("baz/qux").unwrap();
+            msg.topic = topic2.as_ptr() as *mut c_char;
+            assert_eq!(cb(MOSQ_EVT_MESSAGE, &mut msg as *mut _ as *mut c_void, ctx), 1);
+
+            mosquitto_plugin_cleanup(std::ptr::null_mut(), userdata, std::ptr::null_mut(), 0);
+            assert!(REGISTERED.is_none());
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- implement option parsing and publish filtering for Mosquitto plugin
- compile selectors with `moqtail-core`
- provide example config and build instructions
- add unit test using mocked Mosquitto API

## Testing
- `cargo test --manifest-path plugins/mosquitto/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_686be1062e04832888f3fd037e74c00c