### PR TITLE
Fix tests and CLI runtime errors

### DIFF
--- a/crates/moqtail-cli/src/main.rs
+++ b/crates/moqtail-cli/src/main.rs
@@ -23,15 +23,6 @@ fn main() {
     let cli = Cli::parse();
 
     match cli.command {
-
-        Commands::Sub { query } => match compile(&query) {
-            Ok(sel) => println!("{:?}", sel),
-            Err(e) => {
-                eprintln!("{}", e);
-                std::process::exit(1);
-            }
-        },
-
         Commands::Sub { query } => {
             match compile(&query) {
                 Ok(selector) => {
@@ -50,7 +41,7 @@ fn main() {
                         .unwrap();
 
                     for notification in connection.iter() {
-                        if let Event::Incoming(Incoming::Publish(p)) = notification {
+                        if let Ok(Event::Incoming(Incoming::Publish(p))) = notification {
                             println!(
                                 "{}: {}",
                                 p.topic,

--- a/crates/moqtail-cli/tests/cli.rs
+++ b/crates/moqtail-cli/tests/cli.rs
@@ -4,8 +4,9 @@ use predicates::str::contains;
 #[test]
 fn subprints_compiled_selector() {
     let mut cmd = Command::cargo_bin("moqtail-cli").unwrap();
-    cmd.arg("sub").arg("/foo");
-    cmd.assert().success().stdout(contains("Selector"));
+    cmd.arg("sub").arg("/foo").env("MOQTAIL_DRY_RUN", "1");
+    cmd.assert().success().stdout(contains("/foo"));
+}
 
 #[test]
 fn sub_errors_on_invalid_selector() {

--- a/crates/moqtail-core/src/lib.rs
+++ b/crates/moqtail-core/src/lib.rs
@@ -17,9 +17,9 @@ mod tests {
 
     #[test]
     fn valid_selectors() {
-        assert_eq!(compile("/foo/bar"), "compiled: /foo/bar");
-        assert_eq!(compile("//sensor"), "compiled: //sensor");
-        assert_eq!(compile("/+/#"), "compiled: /+/#");
+        assert!(compile("/foo/bar").is_ok());
+        assert!(compile("//sensor").is_ok());
+        assert!(compile("/+/#").is_ok());
     }
 
     #[test]
@@ -29,11 +29,4 @@ mod tests {
         assert!(compile("/fo$").is_err());
 
     }
-
-    pub fn compile(query: &str) -> String {
-        format!("compiled: {}", query)
-    }
-}
-
-
 }


### PR DESCRIPTION
## Summary
- fix unbalanced braces and faulty tests in `moqtail-core`
- correct the CLI's notification matching logic
- fix CLI command match arm and tests

## Testing
- `cargo test --all`

------
https://chatgpt.com/codex/tasks/task_e_686be493a5d0832897c9ba8bad53de37