### PR TITLE
Add coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
+---
 name: CI
 
-on:
+'on':
   push:
-    branches: [ main, work ]
+    branches: [main, work]
   pull_request:
 
 jobs:
@@ -36,3 +37,18 @@ jobs:
 
       - name: Run tests
         run: cargo test --all
+
+      - name: Install cargo-llvm-cov
+        if: runner.os == 'Linux'
+        run: cargo install cargo-llvm-cov --locked
+
+      - name: Generate coverage
+        if: runner.os == 'Linux'
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+
+      - name: Upload coverage artifact
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: lcov.info

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 **/target
 
 **/*.rs.bk
+lcov.info
+
 


### PR DESCRIPTION
## What & Why
Measure code coverage in CI by installing `cargo-llvm-cov` and uploading an
`lcov` report. Also ignore the generated file in git.

## How
* Updated CI workflow to run `cargo llvm-cov` on Linux runners and upload the
  result as an artifact.
* Added `lcov.info` to `.gitignore`.

## Testing
- `cargo fmt --all -- --check`
- `cargo test --all`
- `yamllint .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_686be5ea21e88328a89f72592692916d