### PR TITLE
Add selector regression tests

### DIFF
--- a/crates/moqtail-core/tests/selector.rs
+++ b/crates/moqtail-core/tests/selector.rs
@@ -18,3 +18,58 @@ fn parse_selector_with_predicate() {
         }])
     );
 }
+
+#[test]
+fn parse_selector_with_wildcards() {
+    let sel = compile("/foo/+/#").unwrap();
+    assert_eq!(
+        sel,
+        Selector(vec![
+            Step {
+                axis: Axis::Child,
+                segment: Segment::Literal("foo".into()),
+                predicates: vec![],
+            },
+            Step {
+                axis: Axis::Child,
+                segment: Segment::Plus,
+                predicates: vec![],
+            },
+            Step {
+                axis: Axis::Child,
+                segment: Segment::Hash,
+                predicates: vec![],
+            },
+        ])
+    );
+}
+
+#[test]
+fn parse_selector_descendant() {
+    let sel = compile("//sensor/#").unwrap();
+    assert_eq!(
+        sel,
+        Selector(vec![
+            Step {
+                axis: Axis::Descendant,
+                segment: Segment::Literal("sensor".into()),
+                predicates: vec![],
+            },
+            Step {
+                axis: Axis::Child,
+                segment: Segment::Hash,
+                predicates: vec![],
+            },
+        ])
+    );
+}
+
+#[test]
+fn error_on_trailing_slash() {
+    assert!(compile("/foo/bar/").is_err());
+}
+
+#[test]
+fn error_on_unclosed_predicate() {
+    assert!(compile("/foo[bar=1").is_err());
+}


### PR DESCRIPTION
## Summary
- extend `selector.rs` tests to cover wildcard and descendant parsing
- add error handling cases for trailing slash and malformed predicate

## Testing
- `cargo test --all`
- `cargo test --manifest-path plugins/mosquitto/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_686be5f349008328bce0871103c082dd