### PR TITLE
Add predicate docs and update roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,23 @@ $ cargo install moqtail-cli
 $ moqtail sub "//sensor[@type='temp'][json$.value > 30]"
 ```
 
+```bash
+# Filter using header predicates
+$ moqtail sub "/msg[qos<=1][retained=true]//sensor"
+
+# Match JSON field status
+$ moqtail sub "//device[json$.status='online']"
+```
+
+
 > **Note:** The DSL and tooling are still in early design. Expect syntax tweaks!
 
 ---
 
 ## Roadmap
 
-* [ ] **v0.1**: Minimal XPath‑style selector → topic matcher (no payload introspection).
-* [ ] **v0.2**: Header / property predicates, JSON payload introspection.
+* [x] **v0.1**: Minimal XPath‑style selector → topic matcher (no payload introspection).
+* [x] **v0.2**: Header / property predicates, JSON payload introspection.
 * [ ] **v0.3**: Transform pipeline (`|>`), aggregation windows, broker plugin for Mosquitto.
 * [ ] **v1.0**: Stable grammar spec, full conformance test‑suite, production hardening.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -11,6 +11,14 @@ MoQTail’s development is organised into four milestone releases plus an initia
 | **v0.2 – Header + JSON Predicates**  | Oct 2025      | Message‑metadata predicates, JSON payload introspection, first broker plugin |                                                         |
 | **v0.3 – Transforms & Aggregations** | Jan 2026      | Pipeline operator (\`                                                        | >\`), windows, built‑in functions, multi‑broker support |
 | **v1.0 – Stable Spec**               | Apr 2026      | Grammar freeze, cross‑language libs, production hardening                    |                                                         |
+## Milestone Checklist
+
+- [x] Bootstrap (Phase 0)
+- [x] v0.1 – Topic Selectors
+- [x] v0.2 – Header + JSON Predicates
+- [ ] v0.3 – Transforms & Aggregations
+- [ ] v1.0 – Stable Spec
+
 
 ---
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,3 +1,5 @@
 # Summary
 
 - [Introduction](README.md)
+- [Header Predicates](header_predicates.md)
+- [JSON Payload Selectors](json_payload_selectors.md)

--- a/docs/src/header_predicates.md
+++ b/docs/src/header_predicates.md
@@ -1,0 +1,19 @@
+# Header Predicates
+
+MoQTail selectors can filter on MQTT message headers and properties using the `/msg` axis. Predicates inside `[]` compare metadata fields such as QoS or whether the message was retained.
+
+## Example
+
+```bash
+$ moqtail sub "/msg[qos<=1][retained=true]//sensor"
+```
+
+This subscription matches any retained sensor message published with QoS 0 or 1.
+
+Common header names:
+
+- `qos` – Quality of Service level (0, 1 or 2)
+- `retained` – boolean retained flag
+- `dup` – duplicate delivery flag
+- `prop.<name>` – MQTT v5 user properties
+

--- a/docs/src/json_payload_selectors.md
+++ b/docs/src/json_payload_selectors.md
@@ -1,0 +1,19 @@
+# JSON Payload Selectors
+
+The `json$` axis peeks inside a message payload interpreted as JSON. It uses JSON Pointer style paths so you can match on deeply nested fields.
+
+## Example
+
+```bash
+$ moqtail sub "//device[json$.status='online']"
+```
+
+This matches messages whose JSON payload has `{ "status": "online" }`.
+
+You can combine multiple expressions:
+
+```bash
+$ moqtail sub "//sensor[json$.value > 30][json$.unit='C']"
+```
+
+The payload must be valid UTF‑8 JSON for these predicates to apply.


### PR DESCRIPTION
## Summary
- document header predicates and JSON selectors in mdBook
- add CLI examples for new syntax in README
- mark roadmap progress in README and docs

## Testing
- `cargo test --all`

------
https://chatgpt.com/codex/tasks/task_e_686be91cefc083289730c1e94a5cda65