### PR TITLE
Add header and JSON predicate support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,7 +62,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -58,7 +73,7 @@ checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -90,6 +105,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "backtrace"
+version = "0.3.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +144,12 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "camino"
@@ -139,6 +181,15 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+dependencies = [
+ "shlex",
 ]
 
 [[package]]
@@ -192,6 +243,22 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -250,6 +317,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,10 +369,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -293,10 +430,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "moqtail-cli"
@@ -306,6 +479,7 @@ dependencies = [
  "clap",
  "moqtail-core",
  "predicates 2.1.5",
+ "rumqttc",
 ]
 
 [[package]]
@@ -314,6 +488,7 @@ version = "0.1.0"
 dependencies = [
  "pest",
  "pest_derive",
+ "serde_json",
 ]
 
 [[package]]
@@ -332,10 +507,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "pest"
@@ -380,6 +570,18 @@ dependencies = [
  "pest",
  "sha2",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "predicates"
@@ -470,10 +672,142 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rumqttc"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1568e15fab2d546f940ed3a21f48bbbd1c494c90c99c4481339364a497f94a9"
+dependencies = [
+ "bytes",
+ "flume",
+ "futures-util",
+ "log",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-webpki",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -528,10 +862,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -591,6 +962,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.46.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "io-uring",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "slab",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +1018,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "utf8parse"
@@ -627,6 +1044,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]
@@ -710,3 +1142,9 @@ dependencies = [
  "cargo_metadata",
  "clap",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/crates/moqtail-core/Cargo.toml
+++ b/crates/moqtail-core/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 [dependencies]
 pest = "2"
 pest_derive = "2"
+serde_json = "1"
 

--- a/crates/moqtail-core/src/ast.rs
+++ b/crates/moqtail-core/src/ast.rs
@@ -9,11 +9,35 @@ pub enum Segment {
     Literal(String),
     Plus,
     Hash,
+    Message,
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum Predicate {
-    Equals { name: String, value: String },
+pub enum Field {
+    Header(String),
+    Json(Vec<String>),
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Operator {
+    Eq,
+    Lt,
+    Gt,
+    Le,
+    Ge,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Value {
+    Number(i64),
+    Bool(bool),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Predicate {
+    pub field: Field,
+    pub op: Operator,
+    pub value: Value,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -40,6 +64,7 @@ impl fmt::Display for Selector {
                 Segment::Literal(s) => write!(f, "{}", s)?,
                 Segment::Plus => write!(f, "+")?,
                 Segment::Hash => write!(f, "#")?,
+                Segment::Message => write!(f, "msg")?,
             }
         }
         Ok(())

--- a/crates/moqtail-core/src/lib.rs
+++ b/crates/moqtail-core/src/lib.rs
@@ -4,7 +4,7 @@ pub mod ast;
 mod matcher;
 mod parser;
 
-pub use matcher::Matcher;
+pub use matcher::{Matcher, Message};
 pub use parser::compile;
 
 pub fn hello() -> &'static str {

--- a/crates/moqtail-core/src/matcher.rs
+++ b/crates/moqtail-core/src/matcher.rs
@@ -1,4 +1,12 @@
-use crate::ast::{Axis, Segment, Selector, Step};
+use crate::ast::{Axis, Field, Operator, Segment, Selector, Step, Value, Predicate};
+use serde_json::Value as JsonValue;
+use std::collections::HashMap;
+
+pub struct Message<'a> {
+    pub topic: &'a str,
+    pub headers: HashMap<String, String>,
+    pub payload: Option<JsonValue>,
+}
 
 pub struct Matcher {
     selector: Selector,
@@ -9,26 +17,26 @@ impl Matcher {
         Self { selector }
     }
 
-    pub fn matches(&self, topic: &str) -> bool {
-        let segments: Vec<&str> = if topic.is_empty() {
+    pub fn matches(&self, msg: &Message) -> bool {
+        let segments: Vec<&str> = if msg.topic.is_empty() {
             Vec::new()
         } else {
-            topic.split('/').collect()
+            msg.topic.split('/').collect()
         };
-        Self::match_steps(&self.selector.0, &segments)
+        Self::match_steps(&self.selector.0, &segments, msg)
     }
 
-    fn match_steps(steps: &[Step], topic: &[&str]) -> bool {
+    fn match_steps(steps: &[Step], topic: &[&str], msg: &Message) -> bool {
         if steps.is_empty() {
             return topic.is_empty();
         }
         let step = &steps[0];
         match step.axis {
-            Axis::Child => Self::match_child(step, &steps[1..], topic),
+            Axis::Child => Self::match_child(step, &steps[1..], topic, msg),
             Axis::Descendant => {
                 // try to match at current or any subsequent position
                 for idx in 0..=topic.len() {
-                    if Self::match_child(step, &steps[1..], &topic[idx..]) {
+                    if Self::match_child(step, &steps[1..], &topic[idx..], msg) {
                         return true;
                     }
                     if idx == topic.len() {
@@ -40,12 +48,16 @@ impl Matcher {
         }
     }
 
-    fn match_child(step: &Step, rest: &[Step], topic: &[&str]) -> bool {
+    fn match_child(step: &Step, rest: &[Step], topic: &[&str], msg: &Message) -> bool {
         match step.segment {
             Segment::Literal(ref lit) => {
                 if let Some((first, rest_topic)) = topic.split_first() {
                     if lit == first {
-                        Self::match_steps(rest, rest_topic)
+                        if Self::predicates_match(&step.predicates, msg) {
+                            Self::match_steps(rest, rest_topic, msg)
+                        } else {
+                            false
+                        }
                     } else {
                         false
                     }
@@ -55,23 +67,97 @@ impl Matcher {
             }
             Segment::Plus => {
                 if let Some((_first, rest_topic)) = topic.split_first() {
-                    Self::match_steps(rest, rest_topic)
+                    if Self::predicates_match(&step.predicates, msg) {
+                        Self::match_steps(rest, rest_topic, msg)
+                    } else {
+                        false
+                    }
                 } else {
                     false
                 }
             }
             Segment::Hash => {
                 // Try zero or more segments
-                if Self::match_steps(rest, topic) {
+                if Self::predicates_match(&step.predicates, msg) && Self::match_steps(rest, topic, msg) {
                     return true;
                 }
                 for idx in 0..topic.len() {
-                    if Self::match_steps(rest, &topic[idx + 1..]) {
+                    if Self::match_steps(rest, &topic[idx + 1..], msg) {
                         return true;
                     }
                 }
                 false
             }
+            Segment::Message => {
+                if Self::predicates_match(&step.predicates, msg) {
+                    Self::match_steps(rest, topic, msg)
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
+    fn predicates_match(preds: &[Predicate], msg: &Message) -> bool {
+        for p in preds {
+            if !Self::predicate_match(p, msg) {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn predicate_match(pred: &Predicate, msg: &Message) -> bool {
+        let left = match pred.field {
+            Field::Header(ref name) => {
+                let hv = match msg.headers.get(name) {
+                    Some(v) => v,
+                    None => return false,
+                };
+                if let Ok(num) = hv.parse::<i64>() {
+                    Value::Number(num)
+                } else {
+                    Value::Bool(hv == "true")
+                }
+            }
+            Field::Json(ref path) => {
+                let mut cur = match msg.payload {
+                    Some(ref j) => j,
+                    None => return false,
+                };
+                for part in path {
+                    cur = match cur.get(part) {
+                        Some(v) => v,
+                        None => return false,
+                    };
+                }
+                if let Some(b) = cur.as_bool() {
+                    Value::Bool(b)
+                } else if let Some(n) = cur.as_i64() {
+                    Value::Number(n)
+                } else {
+                    return false;
+                }
+            }
+        };
+
+        Self::compare_values(&left, &pred.value, pred.op)
+    }
+
+    fn compare_values(left: &Value, right: &Value, op: Operator) -> bool {
+        match (left, right) {
+            (Value::Number(l), Value::Number(r)) => match op {
+                Operator::Eq => l == r,
+                Operator::Lt => l < r,
+                Operator::Gt => l > r,
+                Operator::Le => l <= r,
+                Operator::Ge => l >= r,
+            },
+            (Value::Bool(l), Value::Bool(r)) => match op {
+                Operator::Eq => l == r,
+                _ => false,
+            },
+            _ => false,
         }
     }
 }
@@ -80,37 +166,42 @@ impl Matcher {
 mod tests {
     use super::*;
     use crate::parser::compile;
+    use std::collections::HashMap;
+
+    fn make_msg(topic: &str) -> Message<'_> {
+        Message { topic, headers: HashMap::new(), payload: None }
+    }
 
     #[test]
     fn simple_match() {
         let sel = compile("/foo/bar").unwrap();
         let m = Matcher::new(sel);
-        assert!(m.matches("foo/bar"));
-        assert!(!m.matches("foo/baz"));
+        assert!(m.matches(&make_msg("foo/bar")));
+        assert!(!m.matches(&make_msg("foo/baz")));
     }
 
     #[test]
     fn plus_wildcard() {
         let sel = compile("/foo/+").unwrap();
         let m = Matcher::new(sel);
-        assert!(m.matches("foo/bar"));
-        assert!(m.matches("foo/baz"));
-        assert!(!m.matches("foo"));
+        assert!(m.matches(&make_msg("foo/bar")));
+        assert!(m.matches(&make_msg("foo/baz")));
+        assert!(!m.matches(&make_msg("foo")));
     }
 
     #[test]
     fn hash_wildcard() {
         let sel = compile("/foo/#").unwrap();
         let m = Matcher::new(sel);
-        assert!(m.matches("foo"));
-        assert!(m.matches("foo/bar/baz"));
+        assert!(m.matches(&make_msg("foo")));
+        assert!(m.matches(&make_msg("foo/bar/baz")));
     }
 
     #[test]
     fn descendant_axis() {
         let sel = compile("//sensor").unwrap();
         let m = Matcher::new(sel);
-        assert!(m.matches("building/floor/sensor"));
-        assert!(!m.matches("building/floor/actuator"));
+        assert!(m.matches(&make_msg("building/floor/sensor")));
+        assert!(!m.matches(&make_msg("building/floor/actuator")));
     }
 }

--- a/crates/moqtail-core/src/selector.pest
+++ b/crates/moqtail-core/src/selector.pest
@@ -8,10 +8,20 @@ slash = { "//" | "/" }
 
 segment = { wildcard | ident }
 
-predicate = { "[" ~ ident ~ "=" ~ number ~ "]" }
+predicate = { "[" ~ field ~ operator ~ value ~ "]" }
+
+field = { json_field | ident }
+
+json_field = { "json$" ~ ("." ~ ident)+ }
+
+operator = { "<=" | ">=" | "<" | ">" | "=" }
 
 wildcard = { "+" | "#" }
 
 ident = { (ASCII_ALPHANUMERIC | "_" | "-")+ }
 
 number = { ASCII_DIGIT+ }
+
+boolean = { "true" | "false" }
+
+value = { boolean | number }

--- a/crates/moqtail-core/tests/predicate.rs
+++ b/crates/moqtail-core/tests/predicate.rs
@@ -1,0 +1,30 @@
+use std::collections::HashMap;
+use serde_json::json;
+use moqtail_core::{compile, Matcher, Message};
+
+#[test]
+fn header_predicate_match() {
+    let sel = compile("/msg[qos<=1]").unwrap();
+    let msg = Message {
+        topic: "",
+        headers: HashMap::from([
+            ("qos".to_string(), "0".to_string())
+        ]),
+        payload: None,
+    };
+    let m = Matcher::new(sel);
+    assert!(m.matches(&msg));
+}
+
+#[test]
+fn json_predicate_match() {
+    let sel = compile("/foo[json$.temp>30]").unwrap();
+    let payload = json!({"temp": 35});
+    let msg = Message {
+        topic: "foo",
+        headers: HashMap::new(),
+        payload: Some(payload),
+    };
+    let m = Matcher::new(sel);
+    assert!(m.matches(&msg));
+}

--- a/crates/moqtail-core/tests/selector.rs
+++ b/crates/moqtail-core/tests/selector.rs
@@ -1,5 +1,5 @@
 use moqtail_core::{
-    ast::{Axis, Predicate, Segment, Selector, Step},
+    ast::{Axis, Field, Operator, Segment, Selector, Step, Predicate, Value},
     compile,
 };
 
@@ -11,9 +11,10 @@ fn parse_selector_with_predicate() {
         Selector(vec![Step {
             axis: Axis::Child,
             segment: Segment::Literal("foo".into()),
-            predicates: vec![Predicate::Equals {
-                name: "bar".into(),
-                value: "1".into()
+            predicates: vec![Predicate {
+                field: Field::Header("bar".into()),
+                op: Operator::Eq,
+                value: Value::Number(1)
             }],
         }])
     );
@@ -72,4 +73,37 @@ fn error_on_trailing_slash() {
 #[test]
 fn error_on_unclosed_predicate() {
     assert!(compile("/foo[bar=1").is_err());
+}
+
+#[test]
+fn parse_header_axis() {
+    let sel = compile("/msg[qos<=1]/foo").unwrap();
+    assert_eq!(
+        sel,
+        Selector(vec![
+            Step {
+                axis: Axis::Child,
+                segment: Segment::Message,
+                predicates: vec![Predicate { field: Field::Header("qos".into()), op: Operator::Le, value: Value::Number(1) }],
+            },
+            Step {
+                axis: Axis::Child,
+                segment: Segment::Literal("foo".into()),
+                predicates: vec![],
+            }
+        ])
+    );
+}
+
+#[test]
+fn parse_json_predicate() {
+    let sel = compile("/foo[json$.temp>30]").unwrap();
+    assert_eq!(
+        sel,
+        Selector(vec![Step {
+            axis: Axis::Child,
+            segment: Segment::Literal("foo".into()),
+            predicates: vec![Predicate { field: Field::Json(vec!["temp".into()]), op: Operator::Gt, value: Value::Number(30) }],
+        }])
+    );
 }


### PR DESCRIPTION
## Summary
- support header axes and JSON selectors in grammar
- extend AST with predicate comparisons and payload axes
- parse new syntax and build updated AST
- evaluate message metadata and JSON payloads when matching
- test parsing and matching of header and JSON predicates

## Testing
- `cargo test -p moqtail-core`

------
https://chatgpt.com/codex/tasks/task_e_686be91b6e588328ad4c2fd691cbbe04