### PR TITLE
Fix clippy build errors

### DIFF
--- a/crates/moqtail-cli/src/main.rs
+++ b/crates/moqtail-cli/src/main.rs
@@ -23,39 +23,31 @@ fn main() {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Sub { query } => {
-            match compile(&query) {
-                Ok(selector) => {
-                    println!("{}", selector);
-                    if std::env::var("MOQTAIL_DRY_RUN").is_ok() {
-                        return;
-                    }
-
-                    let mut mqttoptions =
-                        MqttOptions::new("moqtail-cli", "localhost", 1883);
-                    mqttoptions.set_keep_alive(Duration::from_secs(5));
-
-                    let (mut client, mut connection) = Client::new(mqttoptions, 10);
-                    client
-                        .subscribe(selector.to_string(), QoS::AtMostOnce)
-                        .unwrap();
-
-                    for notification in connection.iter() {
-                        if let Ok(Event::Incoming(Incoming::Publish(p))) = notification {
-                            println!(
-                                "{}: {}",
-                                p.topic,
-                                String::from_utf8_lossy(&p.payload)
-                            );
-                        }
-                    }
+        Commands::Sub { query } => match compile(&query) {
+            Ok(selector) => {
+                println!("{}", selector);
+                if std::env::var("MOQTAIL_DRY_RUN").is_ok() {
+                    return;
                 }
-                Err(e) => {
-                    eprintln!("Failed to compile selector: {}", e);
-                    std::process::exit(1);
+
+                let mut mqttoptions = MqttOptions::new("moqtail-cli", "localhost", 1883);
+                mqttoptions.set_keep_alive(Duration::from_secs(5));
+
+                let (client, mut connection) = Client::new(mqttoptions, 10);
+                client
+                    .subscribe(selector.to_string(), QoS::AtMostOnce)
+                    .unwrap();
+
+                for event in connection.iter().flatten() {
+                    if let Event::Incoming(Incoming::Publish(p)) = event {
+                        println!("{}: {}", p.topic, String::from_utf8_lossy(&p.payload));
+                    }
                 }
             }
-        }
-
+            Err(e) => {
+                eprintln!("Failed to compile selector: {}", e);
+                std::process::exit(1);
+            }
+        },
     }
 }


### PR DESCRIPTION
## Summary
- clean up unused mut warning in CLI
- streamline publish event loop per clippy

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_686bec42c86083289baa44565730c73e