### PR TITLE
Update upload-artifact action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Upload coverage artifact
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: lcov.info


### PR DESCRIPTION
## Summary
- bump to `actions/upload-artifact@v4` to avoid deprecation notice

## Testing
- `cargo test --all`

------
https://chatgpt.com/codex/tasks/task_e_686bedaa9a28832887d35c82f73a3bf2