### PR TITLE
Implement pipeline operator parsing and execution

### DIFF
--- a/crates/moqtail-core/src/parser.rs
+++ b/crates/moqtail-core/src/parser.rs
@@ -1,7 +1,7 @@
 use pest::Parser;
 use pest_derive::Parser;
 
-use crate::ast::{Axis, Field, Operator, Predicate, Segment, Selector, Step, Value};
+use crate::ast::{Axis, Field, Operator, Predicate, Segment, Selector, Stage, Step, Value};
 
 #[derive(Parser)]
 #[grammar = "selector.pest"]
@@ -11,89 +11,127 @@ pub fn compile(input: &str) -> Result<Selector, String> {
     let mut pairs = SelectorParser::parse(Rule::selector, input).map_err(|e| e.to_string())?;
     let pair = pairs.next().unwrap();
     let mut steps = Vec::new();
+    let mut stages = Vec::new();
 
     for seg in pair.into_inner() {
-        if seg.as_rule() != Rule::path_segment {
-            continue;
-        }
-        let mut inner = seg.into_inner();
-        let axis_pair = inner.next().unwrap();
-        let segment_pair = inner.next().unwrap();
-        let segment_inner = segment_pair.into_inner().next().unwrap();
+        match seg.as_rule() {
+            Rule::path_segment => {
+                let mut inner = seg.into_inner();
+                let axis_pair = inner.next().unwrap();
+                let segment_pair = inner.next().unwrap();
+                let segment_inner = segment_pair.into_inner().next().unwrap();
 
-        let axis = match axis_pair.as_str() {
-            "/" => Axis::Child,
-            "//" => Axis::Descendant,
-            _ => unreachable!(),
-        };
+                let axis = match axis_pair.as_str() {
+                    "/" => Axis::Child,
+                    "//" => Axis::Descendant,
+                    _ => unreachable!(),
+                };
 
-        let segment = match segment_inner.as_rule() {
-            Rule::wildcard => match segment_inner.as_str() {
-                "+" => Segment::Plus,
-                "#" => Segment::Hash,
-                _ => unreachable!(),
-            },
-            Rule::ident => {
-                let s = segment_inner.as_str();
-                if s == "msg" {
-                    Segment::Message
-                } else {
-                    Segment::Literal(s.to_string())
+                let segment = match segment_inner.as_rule() {
+                    Rule::wildcard => match segment_inner.as_str() {
+                        "+" => Segment::Plus,
+                        "#" => Segment::Hash,
+                        _ => unreachable!(),
+                    },
+                    Rule::ident => {
+                        let s = segment_inner.as_str();
+                        if s == "msg" {
+                            Segment::Message
+                        } else {
+                            Segment::Literal(s.to_string())
+                        }
+                    }
+                    _ => unreachable!(),
+                };
+
+                let mut predicates = Vec::new();
+                for pred_pair in inner {
+                    if pred_pair.as_rule() != Rule::predicate {
+                        continue;
+                    }
+                    let mut pred_inner = pred_pair.into_inner();
+                    let field_pair = pred_inner.next().unwrap();
+                    let inner_field = field_pair.into_inner().next().unwrap();
+                    let field = parse_field(inner_field);
+
+                    let op_pair = pred_inner.next().unwrap();
+                    let op = match op_pair.as_str() {
+                        "=" => Operator::Eq,
+                        "<" => Operator::Lt,
+                        ">" => Operator::Gt,
+                        "<=" => Operator::Le,
+                        ">=" => Operator::Ge,
+                        _ => unreachable!(),
+                    };
+
+                    let value_pair = pred_inner.next().unwrap();
+                    let value_inner = value_pair.into_inner().next().unwrap();
+                    let value = match value_inner.as_rule() {
+                        Rule::number => Value::Number(value_inner.as_str().parse().unwrap()),
+                        Rule::boolean => Value::Bool(value_inner.as_str() == "true"),
+                        _ => unreachable!(),
+                    };
+
+                    predicates.push(Predicate { field, op, value });
                 }
+
+                steps.push(Step {
+                    axis,
+                    segment,
+                    predicates,
+                });
             }
-            _ => unreachable!(),
-        };
-
-        let mut predicates = Vec::new();
-        for pred_pair in inner {
-            if pred_pair.as_rule() != Rule::predicate {
-                continue;
+            Rule::stage => {
+                stages.push(parse_stage(seg)?);
             }
-            let mut pred_inner = pred_pair.into_inner();
-            let field_pair = pred_inner.next().unwrap();
-            let inner_field = field_pair.into_inner().next().unwrap();
-            let field = match inner_field.as_rule() {
-                Rule::ident => Field::Header(inner_field.as_str().to_string()),
-                Rule::json_field => {
-                    let text = inner_field.as_str();
-                    let without = text.trim_start_matches("json$");
-                    let parts: Vec<String> = without
-                        .split('.')
-                        .filter(|p| !p.is_empty())
-                        .map(|p| p.to_string())
-                        .collect();
-                    Field::Json(parts)
-                }
-                _ => unreachable!(),
-            };
-
-            let op_pair = pred_inner.next().unwrap();
-            let op = match op_pair.as_str() {
-                "=" => Operator::Eq,
-                "<" => Operator::Lt,
-                ">" => Operator::Gt,
-                "<=" => Operator::Le,
-                ">=" => Operator::Ge,
-                _ => unreachable!(),
-            };
-
-            let value_pair = pred_inner.next().unwrap();
-            let value_inner = value_pair.into_inner().next().unwrap();
-            let value = match value_inner.as_rule() {
-                Rule::number => Value::Number(value_inner.as_str().parse().unwrap()),
-                Rule::boolean => Value::Bool(value_inner.as_str() == "true"),
-                _ => unreachable!(),
-            };
-
-            predicates.push(Predicate { field, op, value });
+            _ => {}
         }
-
-        steps.push(Step {
-            axis,
-            segment,
-            predicates,
-        });
     }
 
-    Ok(Selector(steps))
+    Ok(Selector { steps, stages })
+}
+
+fn parse_field(inner_field: pest::iterators::Pair<Rule>) -> Field {
+    match inner_field.as_rule() {
+        Rule::ident => Field::Header(inner_field.as_str().to_string()),
+        Rule::json_field => {
+            let text = inner_field.as_str();
+            let without = text.trim_start_matches("json$");
+            let parts: Vec<String> = without
+                .split('.')
+                .filter(|p| !p.is_empty())
+                .map(|p| p.to_string())
+                .collect();
+            Field::Json(parts)
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn parse_stage(pair: pest::iterators::Pair<Rule>) -> Result<Stage, String> {
+    let mut inner = pair.into_inner();
+    let func_pair = inner.next().unwrap();
+    let mut func_inner = func_pair.into_inner();
+    let name = func_inner.next().unwrap().as_str();
+    let arg = func_inner.next();
+    match name {
+        "window" => {
+            let a = arg.ok_or_else(|| "window requires duration".to_string())?;
+            let mut ai = a.into_inner();
+            let num = ai.next().unwrap().as_str().parse::<u64>().unwrap();
+            Ok(Stage::Window(num))
+        }
+        "sum" => {
+            let a = arg.ok_or_else(|| "sum requires field".to_string())?;
+            let field_inner = a.into_inner().next().unwrap();
+            Ok(Stage::Sum(parse_field(field_inner)))
+        }
+        "avg" => {
+            let a = arg.ok_or_else(|| "avg requires field".to_string())?;
+            let field_inner = a.into_inner().next().unwrap();
+            Ok(Stage::Avg(parse_field(field_inner)))
+        }
+        "count" => Ok(Stage::Count),
+        _ => Err(format!("unknown function {name}")),
+    }
 }

--- a/crates/moqtail-core/src/selector.pest
+++ b/crates/moqtail-core/src/selector.pest
@@ -1,6 +1,6 @@
 WHITESPACE = _{ " " | "\t" }
 
-selector = { SOI ~ path_segment+ ~ EOI }
+selector = { SOI ~ path_segment+ ~ stage* ~ EOI }
 
 path_segment = { slash ~ segment ~ predicate* }
 
@@ -25,3 +25,9 @@ number = { ASCII_DIGIT+ }
 boolean = { "true" | "false" }
 
 value = { boolean | number }
+
+stage = { pipe ~ function }
+pipe = _{ "|>" }
+function = { ident ~ "(" ~ func_arg? ~ ")" }
+func_arg = _{ duration | field }
+duration = { number ~ "s" }

--- a/crates/moqtail-core/tests/pipeline.rs
+++ b/crates/moqtail-core/tests/pipeline.rs
@@ -1,0 +1,25 @@
+use moqtail_core::{compile, Matcher, Message};
+use serde_json::json;
+use std::collections::HashMap;
+
+#[test]
+fn avg_pipeline() {
+    let sel = compile("/sensor |> window(60s) |> avg(json$.value)").unwrap();
+    let mut m = Matcher::new(sel);
+
+    let headers = HashMap::new();
+
+    let msg1 = Message {
+        topic: "sensor",
+        headers: headers.clone(),
+        payload: Some(json!({"value": 10})),
+    };
+    assert_eq!(m.process(&msg1), Some(10.0));
+
+    let msg2 = Message {
+        topic: "sensor",
+        headers: headers.clone(),
+        payload: Some(json!({"value": 20})),
+    };
+    assert_eq!(m.process(&msg2), Some(15.0));
+}

--- a/crates/moqtail-core/tests/selector.rs
+++ b/crates/moqtail-core/tests/selector.rs
@@ -8,15 +8,18 @@ fn parse_selector_with_predicate() {
     let sel = compile("/foo[bar=1]").unwrap();
     assert_eq!(
         sel,
-        Selector(vec![Step {
-            axis: Axis::Child,
-            segment: Segment::Literal("foo".into()),
-            predicates: vec![Predicate {
-                field: Field::Header("bar".into()),
-                op: Operator::Eq,
-                value: Value::Number(1)
+        Selector {
+            steps: vec![Step {
+                axis: Axis::Child,
+                segment: Segment::Literal("foo".into()),
+                predicates: vec![Predicate {
+                    field: Field::Header("bar".into()),
+                    op: Operator::Eq,
+                    value: Value::Number(1)
+                }],
             }],
-        }])
+            stages: vec![],
+        }
     );
 }
 
@@ -25,23 +28,26 @@ fn parse_selector_with_wildcards() {
     let sel = compile("/foo/+/#").unwrap();
     assert_eq!(
         sel,
-        Selector(vec![
-            Step {
-                axis: Axis::Child,
-                segment: Segment::Literal("foo".into()),
-                predicates: vec![],
-            },
-            Step {
-                axis: Axis::Child,
-                segment: Segment::Plus,
-                predicates: vec![],
-            },
-            Step {
-                axis: Axis::Child,
-                segment: Segment::Hash,
-                predicates: vec![],
-            },
-        ])
+        Selector {
+            steps: vec![
+                Step {
+                    axis: Axis::Child,
+                    segment: Segment::Literal("foo".into()),
+                    predicates: vec![],
+                },
+                Step {
+                    axis: Axis::Child,
+                    segment: Segment::Plus,
+                    predicates: vec![],
+                },
+                Step {
+                    axis: Axis::Child,
+                    segment: Segment::Hash,
+                    predicates: vec![],
+                },
+            ],
+            stages: vec![],
+        }
     );
 }
 
@@ -50,18 +56,21 @@ fn parse_selector_descendant() {
     let sel = compile("//sensor/#").unwrap();
     assert_eq!(
         sel,
-        Selector(vec![
-            Step {
-                axis: Axis::Descendant,
-                segment: Segment::Literal("sensor".into()),
-                predicates: vec![],
-            },
-            Step {
-                axis: Axis::Child,
-                segment: Segment::Hash,
-                predicates: vec![],
-            },
-        ])
+        Selector {
+            steps: vec![
+                Step {
+                    axis: Axis::Descendant,
+                    segment: Segment::Literal("sensor".into()),
+                    predicates: vec![],
+                },
+                Step {
+                    axis: Axis::Child,
+                    segment: Segment::Hash,
+                    predicates: vec![],
+                },
+            ],
+            stages: vec![],
+        }
     );
 }
 
@@ -80,22 +89,25 @@ fn parse_header_axis() {
     let sel = compile("/msg[qos<=1]/foo").unwrap();
     assert_eq!(
         sel,
-        Selector(vec![
-            Step {
-                axis: Axis::Child,
-                segment: Segment::Message,
-                predicates: vec![Predicate {
-                    field: Field::Header("qos".into()),
-                    op: Operator::Le,
-                    value: Value::Number(1)
-                }],
-            },
-            Step {
-                axis: Axis::Child,
-                segment: Segment::Literal("foo".into()),
-                predicates: vec![],
-            }
-        ])
+        Selector {
+            steps: vec![
+                Step {
+                    axis: Axis::Child,
+                    segment: Segment::Message,
+                    predicates: vec![Predicate {
+                        field: Field::Header("qos".into()),
+                        op: Operator::Le,
+                        value: Value::Number(1)
+                    }],
+                },
+                Step {
+                    axis: Axis::Child,
+                    segment: Segment::Literal("foo".into()),
+                    predicates: vec![],
+                }
+            ],
+            stages: vec![],
+        }
     );
 }
 
@@ -104,14 +116,17 @@ fn parse_json_predicate() {
     let sel = compile("/foo[json$.temp>30]").unwrap();
     assert_eq!(
         sel,
-        Selector(vec![Step {
-            axis: Axis::Child,
-            segment: Segment::Literal("foo".into()),
-            predicates: vec![Predicate {
-                field: Field::Json(vec!["temp".into()]),
-                op: Operator::Gt,
-                value: Value::Number(30)
+        Selector {
+            steps: vec![Step {
+                axis: Axis::Child,
+                segment: Segment::Literal("foo".into()),
+                predicates: vec![Predicate {
+                    field: Field::Json(vec!["temp".into()]),
+                    op: Operator::Gt,
+                    value: Value::Number(30)
+                }],
             }],
-        }])
+            stages: vec![],
+        }
     );
 }


### PR DESCRIPTION
## Summary
- support pipeline operator and function calls in parser grammar
- extend AST with `Stage` enum and pipeline stages on `Selector`
- implement pipeline evaluation with windowing and simple aggregations
- parse selectors into new AST structure
- add tests for pipeline, selectors, and updated matcher

## Testing
- `cargo test -p moqtail-core`


------
https://chatgpt.com/codex/tasks/task_e_686bf583156c832895e8f0c16e2ca3d1