### PR TITLE
Handle Message struct in mosquitto plugin

### DIFF
--- a/plugins/mosquitto/Cargo.lock
+++ b/plugins/mosquitto/Cargo.lock
@@ -164,6 +164,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +227,7 @@ version = "0.1.0"
 dependencies = [
  "pest",
  "pest_derive",
+ "serde_json",
 ]
 
 [[package]]
@@ -230,6 +237,7 @@ dependencies = [
  "bindgen",
  "cc",
  "moqtail-core",
+ "serde_json",
 ]
 
 [[package]]
@@ -366,6 +374,44 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/plugins/mosquitto/Cargo.toml
+++ b/plugins/mosquitto/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 moqtail-core = { path = "../../crates/moqtail-core" }
+serde_json = "1"
 
 [build-dependencies]
 cc = "1"


### PR DESCRIPTION
## Summary
- construct `moqtail_core::Message` in `on_message`
- use `matcher.matches(&Message)`
- add serde_json for payload parsing
- extend tests for header and payload cases

## Testing
- `cargo test --manifest-path plugins/mosquitto/Cargo.toml`
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_686bf57f8d948328b20ebfe83ee441e5