### PR TITLE
Add cookbook example

### DIFF
--- a/docs/cookbook/filter_retained_qos1.md
+++ b/docs/cookbook/filter_retained_qos1.md
@@ -1,0 +1,26 @@
+# Filtering Retained QoS≤1 Messages
+
+This recipe demonstrates how to subscribe only to messages that were published with the `retained` flag and with a Quality of Service level of 1 or lower.
+
+## Steps
+
+1. **Start an MQTT broker** (Mosquitto in this example):
+
+   ```bash
+   $ mosquitto -c mosquitto.conf
+   ```
+
+2. **Publish a retained message** with QoS 1:
+
+   ```bash
+   $ mosquitto_pub -t sensors/temp -m '{"value":42}' -r -q 1
+   ```
+
+3. **Subscribe using MoQTail** to filter by `retained` and `QoS`:
+
+   ```bash
+   $ moqtail sub "/msg[retained=true][qos<=1]//sensors"
+   ```
+
+Any retained message with QoS less than or equal to 1 that matches the selector will be delivered to the subscriber.
+

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -3,3 +3,6 @@
 - [Introduction](README.md)
 - [Header Predicates](header_predicates.md)
 - [JSON Payload Selectors](json_payload_selectors.md)
+
+- [Cookbook]
+  - [Filtering Retained QoS≤1 Messages](../cookbook/filter_retained_qos1.md)


### PR DESCRIPTION
## Summary
- start a cookbook folder under `docs`
- document how to filter retained QoS≤1 messages
- link the cookbook example from `SUMMARY.md`

## Testing
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_686bf577771883289d1930f54bfc321f