### PR TITLE
Fix clippy lint on Option::map

### DIFF
--- a/crates/moqtail-core/src/matcher.rs
+++ b/crates/moqtail-core/src/matcher.rs
@@ -215,10 +215,8 @@ impl Matcher {
                 }
                 if let Some(v) = cur.as_f64() {
                     Some(v)
-                } else if let Some(i) = cur.as_i64() {
-                    Some(i as f64)
                 } else {
-                    None
+                    cur.as_i64().map(|i| i as f64)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- remove manual Option::map usage in `extract_field`

## Testing
- `cargo test --workspace --exclude moqtail-python --exclude moqtail-js`

------
https://chatgpt.com/codex/tasks/task_e_686bfdbbd58c8328b6b3bb1408504096