### PR TITLE
Set Python 3.12 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
       - name: Cache cargo registry
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
## Summary
- set up Python 3.12 in the CI workflow

## Testing
- `cargo fmt --all --check`
- `cargo clippy -- -D warnings`
- `cargo test --all` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_686c0271dd508328b03305ca415fa369