### PR TITLE
Update python build docs

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -4,13 +4,24 @@ This package exposes a thin wrapper around `moqtail-core` using [PyO3](https://p
 
 ## Building
 
-1. Install [maturin](https://github.com/PyO3/maturin):
+1. Ensure the Python development headers are installed on your system. On
+   Debian/Ubuntu you can install them via:
+   ```bash
+   sudo apt-get install python3-dev
+   ```
+   If you have multiple Python versions, specify the interpreter for `pyo3` via
+   the `PYO3_PYTHON` environment variable:
+   ```bash
+   export PYO3_PYTHON=$(which python3)
+   ```
+2. Install [maturin](https://github.com/PyO3/maturin):
    ```bash
    pip install maturin
    ```
-2. Build and install the extension module:
+3. Build and install the extension module:
    ```bash
    maturin develop --release
    ```
 
-This will compile the Rust code and make the `moqtail_py` module available in your current Python environment.
+This will compile the Rust code and make the `moqtail_py` module available in
+your current Python environment.


### PR DESCRIPTION
## Summary
- mention Python development headers and `PYO3_PYTHON` in Python binding README

## Testing
- `cargo fmt --all -- --check`
- `cargo test -p moqtail-python` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_686c0603a5c08328a6d5b173b325c5c6