### PR TITLE
Update prerequisites for Python binding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,10 @@ This guide explains the project layout, coding standards, and pull‑request wor
 
 * **Rust** 1.78+ (install via [`rustup`](https://rustup.rs)).
 * **Node.js** 20+ (only if you hack on the JS bindings).
+* **Python** 3 with development headers (needed for `moqtail-python`; e.g. `sudo apt-get install python3-dev`, set `PYO3_PYTHON=$(which python3)` if multiple versions).
 * **GNU Make** (used by `Makefile` shortcuts).
 * **Docker** (optional, for broker plugin testing).
+> **Tip:** On Debian/Ubuntu install the Python development headers with `sudo apt-get install python3-dev`. If you maintain multiple Python versions, set `PYO3_PYTHON=$(which python3)` before building the bindings.
 
 ### Setup
 


### PR DESCRIPTION
## Summary
- document Python requirement for development
- add tip on installing `python3-dev` and using `PYO3_PYTHON`

## Testing
- `make check` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_686d5ade68308328b2d2903913576331