### PR TITLE
Skip python binding by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,10 @@ jobs:
         run: cargo fmt --check
 
       - name: Clippy check
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --workspace --exclude moqtail-python -- -D warnings
 
       - name: Run tests
-        run: cargo test --all
+        run: cargo test --workspace --exclude moqtail-python
 
       - name: Install cargo-llvm-cov
         if: runner.os == 'Linux'
@@ -49,7 +49,7 @@ jobs:
 
       - name: Generate coverage
         if: runner.os == 'Linux'
-        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov --workspace --exclude moqtail-python --lcov --output-path lcov.info
 
       - name: Upload coverage artifact
         if: runner.os == 'Linux'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,13 @@ This guide explains the project layout, coding standards, and pull‑request wor
 
 * **Rust** 1.78+ (install via [`rustup`](https://rustup.rs)).
 * **Node.js** 20+ (only if you hack on the JS bindings).
+* **Python** 3.12+ with development headers (only for the optional Python bindings).
 * **GNU Make** (used by `Makefile` shortcuts).
 * **Docker** (optional, for broker plugin testing).
+
+> **Note:** The `bindings/python` crate depends on PyO3 and isn't built by default.
+> CI skips it via `--workspace --exclude moqtail-python`. Enable it only when the
+> Python prerequisites above are installed.
 
 ### Setup
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,10 @@ members = [
     "bindings/python",
     "bindings/js",
 ]
+default-members = [
+    "xtask",
+    "crates/moqtail-core",
+    "crates/moqtail-cli",
+    "bindings/js",
+]
 resolver = "2"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 check:
 	cargo fmt --all -- --check
-	cargo clippy --all-targets -- -D warnings
-	cargo test --all
+	cargo clippy --workspace --exclude moqtail-python --all-targets -- -D warnings
+	cargo test --workspace --exclude moqtail-python
 
 .PHONY: check


### PR DESCRIPTION
## Summary
- exclude `moqtail-python` from default workspace members
- skip python crate in CI builds
- document how to enable the python crate
- update Makefile to mirror CI

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_686d5ae190b8832882bd6de3658f3eb3