### PR TITLE
Add host and dry-run options

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ $ cargo install moqtail-cli
 
 # 2. Subscribe to high‑temperature alerts
 $ moqtail sub "//sensor[@type='temp'][json$.value > 30]"
+
+# Use a different broker address
+$ moqtail sub --host broker.example.com --port 1884 "//sensor"
+
+# Only check that the query compiles
+$ moqtail sub --dry-run "//sensor"
 ```
 
 ```bash

--- a/crates/moqtail-cli/tests/cli.rs
+++ b/crates/moqtail-cli/tests/cli.rs
@@ -4,14 +4,14 @@ use predicates::str::contains;
 #[test]
 fn subprints_compiled_selector() {
     let mut cmd = Command::cargo_bin("moqtail-cli").unwrap();
-    cmd.arg("sub").arg("/foo").env("MOQTAIL_DRY_RUN", "1");
+    cmd.arg("sub").arg("/foo").arg("--dry-run");
     cmd.assert().success().stdout(contains("/foo"));
 }
 
 #[test]
 fn sub_errors_on_invalid_selector() {
     let mut cmd = Command::cargo_bin("moqtail-cli").unwrap();
-    cmd.arg("sub").arg("foo").env("MOQTAIL_DRY_RUN", "1");
+    cmd.arg("sub").arg("foo").arg("--dry-run");
     cmd.assert()
         .failure()
         .stderr(contains("Failed to compile selector"));


### PR DESCRIPTION
## Summary
- extend `moqtail sub` with `--host`, `--port` and `--dry-run`
- adjust tests for new CLI options
- document flags in README

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p moqtail-cli --quiet`
- `cargo test --all --quiet` *(fails: linking with `cc` failed)*
- `make check` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_686d5adf5e108328a68ad96df48660d1