### PR TITLE
Update mosquitto plugin docs

### DIFF
--- a/plugins/mosquitto/README.md
+++ b/plugins/mosquitto/README.md
@@ -2,6 +2,17 @@
 
 This plugin integrates the MoQTail selector engine into the Mosquitto broker. It parses one or more `plugin_opt_selector` options and filters publish events before they reach subscribing clients.
 
+## System Dependencies
+
+The build links against Mosquitto's C library. Make sure the development
+headers are installed before compiling:
+
+```bash
+sudo apt-get install libmosquitto-dev
+```
+
+Without these headers the plugin cannot be built.
+
 ## Building
 
 ```bash


### PR DESCRIPTION
## Summary
- document system dependencies required for building the Mosquitto plugin

## Testing
- `cargo fmt --all -- --check`
- `cargo test --all` *(fails: undefined reference to Python symbols)*

------
https://chatgpt.com/codex/tasks/task_e_686d5ae13bd48328a1d88ad0f2610978