### PR TITLE
Improve selector display with predicates

### DIFF
--- a/crates/moqtail-core/src/ast.rs
+++ b/crates/moqtail-core/src/ast.rs
@@ -77,6 +77,16 @@ impl fmt::Display for Selector {
                 Segment::Hash => write!(f, "#")?,
                 Segment::Message => write!(f, "msg")?,
             }
+
+            for pred in &step.predicates {
+                write!(
+                    f,
+                    "[{}{}{}]",
+                    display_field(&pred.field),
+                    display_op(pred.op),
+                    display_value(&pred.value)
+                )?;
+            }
         }
         for stage in &self.stages {
             match stage {
@@ -97,5 +107,22 @@ fn display_field(fld: &Field) -> String {
             "json${}",
             parts.iter().map(|p| format!(".{p}")).collect::<String>()
         ),
+    }
+}
+
+fn display_op(op: Operator) -> &'static str {
+    match op {
+        Operator::Eq => "=",
+        Operator::Lt => "<",
+        Operator::Gt => ">",
+        Operator::Le => "<=",
+        Operator::Ge => ">=",
+    }
+}
+
+fn display_value(val: &Value) -> String {
+    match val {
+        Value::Number(n) => n.to_string(),
+        Value::Bool(b) => b.to_string(),
     }
 }

--- a/crates/moqtail-core/tests/display.rs
+++ b/crates/moqtail-core/tests/display.rs
@@ -8,6 +8,12 @@ fn selector_display_roundtrip() {
 }
 
 #[test]
+fn selector_display_with_predicate() {
+    let selector = compile("/foo[bar=1]").unwrap();
+    assert_eq!(selector.to_string(), "/foo[bar=1]");
+}
+
+#[test]
 fn compile_errors_on_unclosed_predicate() {
     let result = compile("/foo[bar=1");
     assert!(result.is_err());


### PR DESCRIPTION
## Summary
- show predicates when formatting selectors
- add test to cover predicate roundtrip

## Testing
- `cargo test -p moqtail-core --lib --tests`

------
https://chatgpt.com/codex/tasks/task_e_688bfe88dcbc832891106923e55a89a7