### PR TITLE
Add license info to crate manifests

### DIFF
--- a/bindings/js/Cargo.toml
+++ b/bindings/js/Cargo.toml
@@ -2,6 +2,7 @@
 name = "moqtail-js"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -2,6 +2,7 @@
 name = "moqtail-python"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [lib]
 name = "moqtail_py"

--- a/crates/moqtail-cli/Cargo.toml
+++ b/crates/moqtail-cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "moqtail-cli"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 moqtail-core = { path = "../moqtail-core" }

--- a/crates/moqtail-core/Cargo.toml
+++ b/crates/moqtail-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "moqtail-core"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 pest = "2"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -2,6 +2,7 @@
 name = "xtask"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }


### PR DESCRIPTION
## Summary
- include the `license` field in each workspace crate
- verify `cargo metadata` works without license warnings

## Testing
- `cargo metadata --format-version 1 --no-deps | jq '.workspace_members | length'`

------
https://chatgpt.com/codex/tasks/task_e_688bfe89e6208328ab7ff8f8bf158205