### PR TITLE
feat: add parser error type

### DIFF
--- a/bindings/js/src/lib.rs
+++ b/bindings/js/src/lib.rs
@@ -6,7 +6,7 @@ use napi_derive::napi;
 fn compile(query: String) -> Result<String, Error> {
     core_compile(&query)
         .map(|sel| sel.to_string())
-        .map_err(Error::from_reason)
+        .map_err(|e| Error::from_reason(e.to_string()))
 }
 
 #[napi]

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -5,7 +5,7 @@ use pyo3::prelude::*;
 fn compile(query: &str) -> PyResult<String> {
     core_compile(query)
         .map(|sel| sel.to_string())
-        .map_err(pyo3::exceptions::PyValueError::new_err)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
 }
 
 #[pyfunction]

--- a/crates/moqtail-core/src/lib.rs
+++ b/crates/moqtail-core/src/lib.rs
@@ -5,7 +5,7 @@ mod matcher;
 mod parser;
 
 pub use matcher::{Matcher, Message};
-pub use parser::compile;
+pub use parser::{compile, Error};
 
 pub fn hello() -> &'static str {
     "Hello, MoQtail!"

--- a/crates/moqtail-core/src/parser.rs
+++ b/crates/moqtail-core/src/parser.rs
@@ -3,13 +3,44 @@ use pest_derive::Parser;
 
 use crate::ast::{Axis, Field, Operator, Predicate, Segment, Selector, Stage, Step, Value};
 
+#[derive(Debug)]
+pub enum Error {
+    Pest(pest::error::Error<Rule>),
+    Message(String),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Pest(e) => write!(f, "{e}"),
+            Error::Message(m) => write!(f, "{m}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<pest::error::Error<Rule>> for Error {
+    fn from(e: pest::error::Error<Rule>) -> Self {
+        Error::Pest(e)
+    }
+}
+
+impl From<std::num::ParseIntError> for Error {
+    fn from(e: std::num::ParseIntError) -> Self {
+        Error::Message(e.to_string())
+    }
+}
+
 #[derive(Parser)]
 #[grammar = "selector.pest"]
 struct SelectorParser;
 
-pub fn compile(input: &str) -> Result<Selector, String> {
-    let mut pairs = SelectorParser::parse(Rule::selector, input).map_err(|e| e.to_string())?;
-    let pair = pairs.next().unwrap();
+pub fn compile(input: &str) -> Result<Selector, Error> {
+    let mut pairs = SelectorParser::parse(Rule::selector, input)?;
+    let pair = pairs
+        .next()
+        .ok_or_else(|| Error::Message("missing selector".into()))?;
     let mut steps = Vec::new();
     let mut stages = Vec::new();
 
@@ -17,21 +48,28 @@ pub fn compile(input: &str) -> Result<Selector, String> {
         match seg.as_rule() {
             Rule::path_segment => {
                 let mut inner = seg.into_inner();
-                let axis_pair = inner.next().unwrap();
-                let segment_pair = inner.next().unwrap();
-                let segment_inner = segment_pair.into_inner().next().unwrap();
+                let axis_pair = inner
+                    .next()
+                    .ok_or_else(|| Error::Message("missing axis".into()))?;
+                let segment_pair = inner
+                    .next()
+                    .ok_or_else(|| Error::Message("missing segment".into()))?;
+                let segment_inner = segment_pair
+                    .into_inner()
+                    .next()
+                    .ok_or_else(|| Error::Message("missing segment".into()))?;
 
                 let axis = match axis_pair.as_str() {
                     "/" => Axis::Child,
                     "//" => Axis::Descendant,
-                    _ => unreachable!(),
+                    other => return Err(Error::Message(format!("unknown axis {other}"))),
                 };
 
                 let segment = match segment_inner.as_rule() {
                     Rule::wildcard => match segment_inner.as_str() {
                         "+" => Segment::Plus,
                         "#" => Segment::Hash,
-                        _ => unreachable!(),
+                        other => return Err(Error::Message(format!("unknown wildcard {other}"))),
                     },
                     Rule::ident => {
                         let s = segment_inner.as_str();
@@ -41,7 +79,7 @@ pub fn compile(input: &str) -> Result<Selector, String> {
                             Segment::Literal(s.to_string())
                         }
                     }
-                    _ => unreachable!(),
+                    _ => return Err(Error::Message("invalid segment".into())),
                 };
 
                 let mut predicates = Vec::new();
@@ -50,26 +88,38 @@ pub fn compile(input: &str) -> Result<Selector, String> {
                         continue;
                     }
                     let mut pred_inner = pred_pair.into_inner();
-                    let field_pair = pred_inner.next().unwrap();
-                    let inner_field = field_pair.into_inner().next().unwrap();
+                    let field_pair = pred_inner
+                        .next()
+                        .ok_or_else(|| Error::Message("missing field".into()))?;
+                    let inner_field = field_pair
+                        .into_inner()
+                        .next()
+                        .ok_or_else(|| Error::Message("missing field".into()))?;
                     let field = parse_field(inner_field);
 
-                    let op_pair = pred_inner.next().unwrap();
+                    let op_pair = pred_inner
+                        .next()
+                        .ok_or_else(|| Error::Message("missing operator".into()))?;
                     let op = match op_pair.as_str() {
                         "=" => Operator::Eq,
                         "<" => Operator::Lt,
                         ">" => Operator::Gt,
                         "<=" => Operator::Le,
                         ">=" => Operator::Ge,
-                        _ => unreachable!(),
+                        other => return Err(Error::Message(format!("unknown operator {other}"))),
                     };
 
-                    let value_pair = pred_inner.next().unwrap();
-                    let value_inner = value_pair.into_inner().next().unwrap();
+                    let value_pair = pred_inner
+                        .next()
+                        .ok_or_else(|| Error::Message("missing value".into()))?;
+                    let value_inner = value_pair
+                        .into_inner()
+                        .next()
+                        .ok_or_else(|| Error::Message("missing value".into()))?;
                     let value = match value_inner.as_rule() {
-                        Rule::number => Value::Number(value_inner.as_str().parse().unwrap()),
+                        Rule::number => Value::Number(value_inner.as_str().parse::<i64>()?),
                         Rule::boolean => Value::Bool(value_inner.as_str() == "true"),
-                        _ => unreachable!(),
+                        _ => return Err(Error::Message("invalid value".into())),
                     };
 
                     predicates.push(Predicate { field, op, value });
@@ -108,30 +158,44 @@ fn parse_field(inner_field: pest::iterators::Pair<Rule>) -> Field {
     }
 }
 
-fn parse_stage(pair: pest::iterators::Pair<Rule>) -> Result<Stage, String> {
+fn parse_stage(pair: pest::iterators::Pair<Rule>) -> Result<Stage, Error> {
     let mut inner = pair.into_inner();
-    let func_pair = inner.next().unwrap();
+    let func_pair = inner
+        .next()
+        .ok_or_else(|| Error::Message("missing function".into()))?;
     let mut func_inner = func_pair.into_inner();
-    let name = func_inner.next().unwrap().as_str();
+    let name = func_inner
+        .next()
+        .ok_or_else(|| Error::Message("missing function name".into()))?
+        .as_str();
     let arg = func_inner.next();
     match name {
         "window" => {
-            let a = arg.ok_or_else(|| "window requires duration".to_string())?;
+            let a = arg.ok_or_else(|| Error::Message("window requires duration".into()))?;
             let mut ai = a.into_inner();
-            let num = ai.next().unwrap().as_str().parse::<u64>().unwrap();
+            let num_pair = ai
+                .next()
+                .ok_or_else(|| Error::Message("window requires duration".into()))?;
+            let num = num_pair.as_str().parse::<u64>()?;
             Ok(Stage::Window(num))
         }
         "sum" => {
-            let a = arg.ok_or_else(|| "sum requires field".to_string())?;
-            let field_inner = a.into_inner().next().unwrap();
+            let a = arg.ok_or_else(|| Error::Message("sum requires field".into()))?;
+            let field_inner = a
+                .into_inner()
+                .next()
+                .ok_or_else(|| Error::Message("sum requires field".into()))?;
             Ok(Stage::Sum(parse_field(field_inner)))
         }
         "avg" => {
-            let a = arg.ok_or_else(|| "avg requires field".to_string())?;
-            let field_inner = a.into_inner().next().unwrap();
+            let a = arg.ok_or_else(|| Error::Message("avg requires field".into()))?;
+            let field_inner = a
+                .into_inner()
+                .next()
+                .ok_or_else(|| Error::Message("avg requires field".into()))?;
             Ok(Stage::Avg(parse_field(field_inner)))
         }
         "count" => Ok(Stage::Count),
-        _ => Err(format!("unknown function {name}")),
+        _ => Err(Error::Message(format!("unknown function {name}"))),
     }
 }


### PR DESCRIPTION
## Summary
- introduce `Error` enum to represent parser failures and remove panics
- expose `Error` from core library and update bindings to map errors via `Display`

## Testing
- `cargo test --workspace` *(fails: linking with `cc` failed: undefined reference to `_Py_Dealloc`)*
- `cargo test --workspace --exclude moqtail-python --exclude moqtail-js`
- `cargo test --manifest-path plugins/emqx/Cargo.toml`
- `cargo test --manifest-path plugins/mosquitto/Cargo.toml` *(fails: fatal error: 'mosquitto_broker.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68939bcf72048328bc04c9fef126cdfa