### PR TITLE
Mosquitto plugin: log malformed JSON payloads

### DIFF
--- a/plugins/mosquitto/src/lib.rs
+++ b/plugins/mosquitto/src/lib.rs
@@ -41,7 +41,10 @@ extern "C" fn on_message(_: c_int, event_data: *mut c_void, userdata: *mut c_voi
             let bytes = slice::from_raw_parts(msg.payload as *const u8, msg.payloadlen as usize);
             match serde_json::from_slice::<JsonValue>(bytes) {
                 Ok(j) => Some(j),
-                Err(_) => None,
+                Err(e) => {
+                    eprintln!("[MoQTail] payload JSON parse error: {}", e);
+                    return 1;
+                }
             }
         } else {
             None

--- a/plugins/mosquitto/tests/malformed.rs
+++ b/plugins/mosquitto/tests/malformed.rs
@@ -1,0 +1,76 @@
+use std::ffi::CString;
+use std::os::raw::{c_char, c_int, c_void};
+extern crate moqtail_mosquitto;
+use moqtail_mosquitto::{
+    mosquitto_evt_message, mosquitto_opt, mosquitto_plugin_cleanup, mosquitto_plugin_init,
+};
+
+static mut REGISTERED: Option<(
+    extern "C" fn(c_int, *mut c_void, *mut c_void) -> c_int,
+    *mut c_void,
+)> = None;
+
+#[no_mangle]
+unsafe extern "C" fn mosquitto_callback_register(
+    _identifier: *mut c_void,
+    _event: c_int,
+    cb_func: Option<extern "C" fn(c_int, *mut c_void, *mut c_void) -> c_int>,
+    _event_data: *const c_void,
+    userdata: *mut c_void,
+) -> c_int {
+    if let Some(f) = cb_func {
+        REGISTERED = Some((f, userdata));
+    }
+    0
+}
+
+#[no_mangle]
+unsafe extern "C" fn mosquitto_callback_unregister(
+    _identifier: *mut c_void,
+    _event: c_int,
+    _cb_func: Option<extern "C" fn(c_int, *mut c_void, *mut c_void) -> c_int>,
+    _event_data: *const c_void,
+) -> c_int {
+    REGISTERED = None;
+    0
+}
+
+#[test]
+fn malformed_json() {
+    unsafe {
+        let key = CString::new("selector").unwrap();
+        let val = CString::new("/foo").unwrap();
+        let mut opt = mosquitto_opt {
+            key: key.as_ptr() as *mut c_char,
+            value: val.as_ptr() as *mut c_char,
+        };
+        let mut userdata: *mut c_void = std::ptr::null_mut();
+
+        assert_eq!(
+            mosquitto_plugin_init(std::ptr::null_mut(), &mut userdata, &mut opt, 1),
+            0
+        );
+        let (cb, ctx) = REGISTERED.expect("callback registered");
+
+        let topic = CString::new("foo").unwrap();
+        let payload = CString::new("{invalid json").unwrap();
+        let mut msg = mosquitto_evt_message {
+            future: std::ptr::null_mut(),
+            client: std::ptr::null_mut(),
+            topic: topic.as_ptr() as *mut c_char,
+            payload: payload.as_ptr() as *mut c_void,
+            properties: std::ptr::null_mut(),
+            reason_string: std::ptr::null_mut(),
+            payloadlen: payload.as_bytes().len() as u32,
+            qos: 0,
+            reason_code: 0,
+            retain: false,
+            future2: [std::ptr::null_mut(); 4],
+        };
+
+        assert_eq!(cb(7, &mut msg as *mut _ as *mut c_void, ctx), 1);
+
+        mosquitto_plugin_cleanup(std::ptr::null_mut(), userdata, std::ptr::null_mut(), 0);
+        assert!(REGISTERED.is_none());
+    }
+}


### PR DESCRIPTION
## Summary
- log and fail when incoming MQTT payload is not valid JSON
- add integration test covering malformed payload handling

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68939bcc046c8328918f9838e0f4ec69