### PR TITLE
Handle subscription and connection errors in CLI

### DIFF
--- a/crates/moqtail-cli/tests/cli.rs
+++ b/crates/moqtail-cli/tests/cli.rs
@@ -16,3 +16,12 @@ fn sub_errors_on_invalid_selector() {
         .failure()
         .stderr(contains("Failed to compile selector"));
 }
+
+#[test]
+fn sub_errors_on_connection_failure() {
+    let mut cmd = Command::cargo_bin("moqtail-cli").unwrap();
+    cmd.arg("sub").arg("/foo").arg("--host").arg("invalid");
+    cmd.assert()
+        .failure()
+        .stderr(contains("Connection error"));
+}


### PR DESCRIPTION
## Summary
- Gracefully handle MQTT subscribe failures in moqtail-cli
- Surface connection errors instead of silently flattening them
- Test for connection failure handling in CLI

## Testing
- `cargo test -p moqtail-cli`


------
https://chatgpt.com/codex/tasks/task_e_68939bcd3e0483289ec53a10c092651e