### PR TITLE
Add tests for sum and count pipelines

### DIFF
--- a/crates/moqtail-core/tests/pipeline.rs
+++ b/crates/moqtail-core/tests/pipeline.rs
@@ -23,3 +23,60 @@ fn avg_pipeline() {
     };
     assert_eq!(m.process(&msg2), Some(15.0));
 }
+
+#[test]
+fn sum_pipeline() {
+    let sel = compile("/sensor |> window(60s) |> sum(json$.value)").unwrap();
+    let mut m = Matcher::new(sel);
+
+    let headers = HashMap::new();
+
+    let msg1 = Message {
+        topic: "sensor",
+        headers: headers.clone(),
+        payload: Some(json!({"value": 10})),
+    };
+    assert_eq!(m.process(&msg1), Some(10.0));
+
+    let msg2 = Message {
+        topic: "sensor",
+        headers: headers.clone(),
+        payload: Some(json!({"value": 20})),
+    };
+    assert_eq!(m.process(&msg2), Some(30.0));
+}
+
+#[test]
+fn count_pipeline() {
+    let sel = compile("/sensor |> window(60s) |> count()").unwrap();
+    let mut m = Matcher::new(sel);
+
+    let headers = HashMap::new();
+
+    let msg1 = Message {
+        topic: "sensor",
+        headers: headers.clone(),
+        payload: None,
+    };
+    assert_eq!(m.process(&msg1), Some(1.0));
+
+    let msg2 = Message {
+        topic: "sensor",
+        headers: headers,
+        payload: None,
+    };
+    assert_eq!(m.process(&msg2), Some(2.0));
+}
+
+#[test]
+fn sum_missing_field() {
+    let sel = compile("/sensor |> window(60s) |> sum(json$.value)").unwrap();
+    let mut m = Matcher::new(sel);
+
+    let msg = Message {
+        topic: "sensor",
+        headers: HashMap::new(),
+        payload: Some(json!({"other": 10})),
+    };
+    assert_eq!(m.process(&msg), None);
+}


### PR DESCRIPTION
## Summary
- test sum pipeline aggregation on windowed stream
- test count pipeline for message tally
- ensure missing JSON field returns None

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689d27717f00832886e219b43f60e385