### PR TITLE
feat(core): add detailed parser errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,6 +539,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/crates/moqtail-core/Cargo.toml
+++ b/crates/moqtail-core/Cargo.toml
@@ -8,4 +8,5 @@ license = "MIT OR Apache-2.0"
 pest = "2"
 pest_derive = "2"
 serde_json = "1"
+thiserror = "1"
 

--- a/crates/moqtail-core/src/parser.rs
+++ b/crates/moqtail-core/src/parser.rs
@@ -2,34 +2,48 @@ use pest::Parser;
 use pest_derive::Parser;
 
 use crate::ast::{Axis, Field, Operator, Predicate, Segment, Selector, Stage, Step, Value};
+use thiserror::Error;
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum Error {
-    Pest(pest::error::Error<Rule>),
-    Message(String),
-}
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::Pest(e) => write!(f, "{e}"),
-            Error::Message(m) => write!(f, "{m}"),
-        }
-    }
-}
-
-impl std::error::Error for Error {}
-
-impl From<pest::error::Error<Rule>> for Error {
-    fn from(e: pest::error::Error<Rule>) -> Self {
-        Error::Pest(e)
-    }
-}
-
-impl From<std::num::ParseIntError> for Error {
-    fn from(e: std::num::ParseIntError) -> Self {
-        Error::Message(e.to_string())
-    }
+    #[error(transparent)]
+    Pest(#[from] pest::error::Error<Rule>),
+    #[error(transparent)]
+    ParseInt(#[from] std::num::ParseIntError),
+    #[error("missing selector")]
+    MissingSelector,
+    #[error("missing axis")]
+    MissingAxis,
+    #[error("missing segment")]
+    MissingSegment,
+    #[error("unknown axis {0}")]
+    UnknownAxis(String),
+    #[error("unknown wildcard {0}")]
+    UnknownWildcard(String),
+    #[error("invalid segment")]
+    InvalidSegment,
+    #[error("missing field")]
+    MissingField,
+    #[error("missing operator")]
+    MissingOperator,
+    #[error("unknown operator {0}")]
+    UnknownOperator(String),
+    #[error("missing value")]
+    MissingValue,
+    #[error("invalid value")]
+    InvalidValue,
+    #[error("missing function")]
+    MissingFunction,
+    #[error("missing function name")]
+    MissingFunctionName,
+    #[error("window requires duration")]
+    WindowRequiresDuration,
+    #[error("sum requires field")]
+    SumRequiresField,
+    #[error("avg requires field")]
+    AvgRequiresField,
+    #[error("unknown function {0}")]
+    UnknownFunction(String),
 }
 
 #[derive(Parser)]
@@ -38,9 +52,7 @@ struct SelectorParser;
 
 pub fn compile(input: &str) -> Result<Selector, Error> {
     let mut pairs = SelectorParser::parse(Rule::selector, input)?;
-    let pair = pairs
-        .next()
-        .ok_or_else(|| Error::Message("missing selector".into()))?;
+    let pair = pairs.next().ok_or(Error::MissingSelector)?;
     let mut steps = Vec::new();
     let mut stages = Vec::new();
 
@@ -48,28 +60,24 @@ pub fn compile(input: &str) -> Result<Selector, Error> {
         match seg.as_rule() {
             Rule::path_segment => {
                 let mut inner = seg.into_inner();
-                let axis_pair = inner
-                    .next()
-                    .ok_or_else(|| Error::Message("missing axis".into()))?;
-                let segment_pair = inner
-                    .next()
-                    .ok_or_else(|| Error::Message("missing segment".into()))?;
+                let axis_pair = inner.next().ok_or(Error::MissingAxis)?;
+                let segment_pair = inner.next().ok_or(Error::MissingSegment)?;
                 let segment_inner = segment_pair
                     .into_inner()
                     .next()
-                    .ok_or_else(|| Error::Message("missing segment".into()))?;
+                    .ok_or(Error::MissingSegment)?;
 
                 let axis = match axis_pair.as_str() {
                     "/" => Axis::Child,
                     "//" => Axis::Descendant,
-                    other => return Err(Error::Message(format!("unknown axis {other}"))),
+                    other => return Err(Error::UnknownAxis(other.to_string())),
                 };
 
                 let segment = match segment_inner.as_rule() {
                     Rule::wildcard => match segment_inner.as_str() {
                         "+" => Segment::Plus,
                         "#" => Segment::Hash,
-                        other => return Err(Error::Message(format!("unknown wildcard {other}"))),
+                        other => return Err(Error::UnknownWildcard(other.to_string())),
                     },
                     Rule::ident => {
                         let s = segment_inner.as_str();
@@ -79,7 +87,7 @@ pub fn compile(input: &str) -> Result<Selector, Error> {
                             Segment::Literal(s.to_string())
                         }
                     }
-                    _ => return Err(Error::Message("invalid segment".into())),
+                    _ => return Err(Error::InvalidSegment),
                 };
 
                 let mut predicates = Vec::new();
@@ -88,38 +96,26 @@ pub fn compile(input: &str) -> Result<Selector, Error> {
                         continue;
                     }
                     let mut pred_inner = pred_pair.into_inner();
-                    let field_pair = pred_inner
-                        .next()
-                        .ok_or_else(|| Error::Message("missing field".into()))?;
-                    let inner_field = field_pair
-                        .into_inner()
-                        .next()
-                        .ok_or_else(|| Error::Message("missing field".into()))?;
+                    let field_pair = pred_inner.next().ok_or(Error::MissingField)?;
+                    let inner_field = field_pair.into_inner().next().ok_or(Error::MissingField)?;
                     let field = parse_field(inner_field);
 
-                    let op_pair = pred_inner
-                        .next()
-                        .ok_or_else(|| Error::Message("missing operator".into()))?;
+                    let op_pair = pred_inner.next().ok_or(Error::MissingOperator)?;
                     let op = match op_pair.as_str() {
                         "=" => Operator::Eq,
                         "<" => Operator::Lt,
                         ">" => Operator::Gt,
                         "<=" => Operator::Le,
                         ">=" => Operator::Ge,
-                        other => return Err(Error::Message(format!("unknown operator {other}"))),
+                        other => return Err(Error::UnknownOperator(other.to_string())),
                     };
 
-                    let value_pair = pred_inner
-                        .next()
-                        .ok_or_else(|| Error::Message("missing value".into()))?;
-                    let value_inner = value_pair
-                        .into_inner()
-                        .next()
-                        .ok_or_else(|| Error::Message("missing value".into()))?;
+                    let value_pair = pred_inner.next().ok_or(Error::MissingValue)?;
+                    let value_inner = value_pair.into_inner().next().ok_or(Error::MissingValue)?;
                     let value = match value_inner.as_rule() {
                         Rule::number => Value::Number(value_inner.as_str().parse::<i64>()?),
                         Rule::boolean => Value::Bool(value_inner.as_str() == "true"),
-                        _ => return Err(Error::Message("invalid value".into())),
+                        _ => return Err(Error::InvalidValue),
                     };
 
                     predicates.push(Predicate { field, op, value });
@@ -160,42 +156,32 @@ fn parse_field(inner_field: pest::iterators::Pair<Rule>) -> Field {
 
 fn parse_stage(pair: pest::iterators::Pair<Rule>) -> Result<Stage, Error> {
     let mut inner = pair.into_inner();
-    let func_pair = inner
-        .next()
-        .ok_or_else(|| Error::Message("missing function".into()))?;
+    let func_pair = inner.next().ok_or(Error::MissingFunction)?;
     let mut func_inner = func_pair.into_inner();
     let name = func_inner
         .next()
-        .ok_or_else(|| Error::Message("missing function name".into()))?
+        .ok_or(Error::MissingFunctionName)?
         .as_str();
     let arg = func_inner.next();
     match name {
         "window" => {
-            let a = arg.ok_or_else(|| Error::Message("window requires duration".into()))?;
+            let a = arg.ok_or(Error::WindowRequiresDuration)?;
             let mut ai = a.into_inner();
-            let num_pair = ai
-                .next()
-                .ok_or_else(|| Error::Message("window requires duration".into()))?;
+            let num_pair = ai.next().ok_or(Error::WindowRequiresDuration)?;
             let num = num_pair.as_str().parse::<u64>()?;
             Ok(Stage::Window(num))
         }
         "sum" => {
-            let a = arg.ok_or_else(|| Error::Message("sum requires field".into()))?;
-            let field_inner = a
-                .into_inner()
-                .next()
-                .ok_or_else(|| Error::Message("sum requires field".into()))?;
+            let a = arg.ok_or(Error::SumRequiresField)?;
+            let field_inner = a.into_inner().next().ok_or(Error::SumRequiresField)?;
             Ok(Stage::Sum(parse_field(field_inner)))
         }
         "avg" => {
-            let a = arg.ok_or_else(|| Error::Message("avg requires field".into()))?;
-            let field_inner = a
-                .into_inner()
-                .next()
-                .ok_or_else(|| Error::Message("avg requires field".into()))?;
+            let a = arg.ok_or(Error::AvgRequiresField)?;
+            let field_inner = a.into_inner().next().ok_or(Error::AvgRequiresField)?;
             Ok(Stage::Avg(parse_field(field_inner)))
         }
         "count" => Ok(Stage::Count),
-        _ => Err(Error::Message(format!("unknown function {name}"))),
+        _ => Err(Error::UnknownFunction(name.to_string())),
     }
 }


### PR DESCRIPTION
## Summary
- derive `thiserror::Error` for parser errors
- replace generic parser error messages with specific variants
- update parser logic to use variant-based errors

## Testing
- `cargo test -p moqtail-core`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689d276c33708328bab306cc199bcada