### PR TITLE
Use stack-based matcher and test deep topics

### DIFF
--- a/crates/moqtail-core/tests/long_topic.rs
+++ b/crates/moqtail-core/tests/long_topic.rs
@@ -40,3 +40,33 @@ fn no_match_in_long_topic() {
     };
     assert!(!matcher.matches(&msg));
 }
+
+#[test]
+fn matches_descendant_in_very_long_topic() {
+    let selector = compile("//sensor").unwrap();
+    let matcher = Matcher::new(selector);
+    let topic = build_topic(10_000, "sensor");
+    let msg = Message {
+        topic: &topic,
+        headers: HashMap::new(),
+        payload: None,
+    };
+    assert!(
+        matcher.matches(&msg),
+        "selector should match very long topic: {}",
+        topic
+    );
+}
+
+#[test]
+fn no_match_in_very_long_topic() {
+    let selector = compile("//sensor").unwrap();
+    let matcher = Matcher::new(selector);
+    let topic = build_topic(10_000, "other");
+    let msg = Message {
+        topic: &topic,
+        headers: HashMap::new(),
+        payload: None,
+    };
+    assert!(!matcher.matches(&msg));
+}


### PR DESCRIPTION
## Summary
- replace recursive matcher logic with stack-based traversal
- add regression tests for matching very deep topic paths

## Testing
- `cargo test -p moqtail-core`
- `cargo test -p moqtail-core --test long_topic`


------
https://chatgpt.com/codex/tasks/task_e_689f4ca4276083288cd23e5d3fd831f3