### PR TITLE
Remove hello API

### DIFF
--- a/bindings/js/README.md
+++ b/bindings/js/README.md
@@ -16,5 +16,5 @@ These bindings expose `moqtail-core` to Node.js using [napi-rs](https://napi.rs/
 The resulting `moqtail-js.node` binary will be placed next to `index.js` and can be required as:
 
 ```javascript
-const { compile, hello } = require('moqtail-js');
+const { compile } = require('moqtail-js');
 ```

--- a/bindings/js/src/lib.rs
+++ b/bindings/js/src/lib.rs
@@ -1,4 +1,4 @@
-use moqtail_core::{compile as core_compile, hello as core_hello};
+use moqtail_core::compile as core_compile;
 use napi::Error;
 use napi_derive::napi;
 
@@ -9,11 +9,6 @@ fn compile(query: String) -> Result<String, Error> {
         .map_err(|e| Error::from_reason(e.to_string()))
 }
 
-#[napi]
-fn hello() -> &'static str {
-    core_hello()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -21,10 +16,5 @@ mod tests {
     #[test]
     fn compile_returns_string() {
         assert_eq!(compile("/foo".into()).unwrap(), "/foo");
-    }
-
-    #[test]
-    fn hello_returns_greeting() {
-        assert_eq!(hello(), "Hello, MoQtail!");
     }
 }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,4 +1,4 @@
-use moqtail_core::{compile as core_compile, hello as core_hello};
+use moqtail_core::compile as core_compile;
 use pyo3::prelude::*;
 
 #[pyfunction]
@@ -8,15 +8,9 @@ fn compile(query: &str) -> PyResult<String> {
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
 }
 
-#[pyfunction]
-fn hello() -> &'static str {
-    core_hello()
-}
-
 #[pymodule]
 fn moqtail_py(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(compile, m)?)?;
-    m.add_function(wrap_pyfunction!(hello, m)?)?;
     Ok(())
 }
 
@@ -27,10 +21,5 @@ mod tests {
     #[test]
     fn compile_returns_string() {
         assert_eq!(compile("/foo").unwrap(), "/foo");
-    }
-
-    #[test]
-    fn hello_returns_greeting() {
-        assert_eq!(hello(), "Hello, MoQtail!");
     }
 }

--- a/crates/moqtail-core/src/lib.rs
+++ b/crates/moqtail-core/src/lib.rs
@@ -7,10 +7,6 @@ mod parser;
 pub use matcher::{Matcher, Message};
 pub use parser::{compile, Error};
 
-pub fn hello() -> &'static str {
-    "Hello, MoQtail!"
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -27,10 +23,5 @@ mod tests {
         assert!(compile("foo/bar").is_err());
         assert!(compile("/foo//").is_err());
         assert!(compile("/fo$").is_err());
-    }
-
-    #[test]
-    fn hello_returns_greeting() {
-        assert_eq!(hello(), "Hello, MoQtail!");
     }
 }


### PR DESCRIPTION
## Summary
- remove `hello` from the core crate
- drop `hello` exports from Python and JS bindings
- update JavaScript README example

## Testing
- `cargo test`
- `rg hello -n`


------
https://chatgpt.com/codex/tasks/task_e_689f4ca0753c8328a3728451a5a60678