### PR TITLE
Handle JSON field prefix correctly

### DIFF
--- a/crates/moqtail-core/src/parser.rs
+++ b/crates/moqtail-core/src/parser.rs
@@ -142,7 +142,13 @@ fn parse_field(inner_field: pest::iterators::Pair<Rule>) -> Field {
         Rule::ident => Field::Header(inner_field.as_str().to_string()),
         Rule::json_field => {
             let text = inner_field.as_str();
-            let without = text.trim_start_matches("json$");
+            let without = match text.strip_prefix("json$") {
+                Some(rest) => rest,
+                None => {
+                    // this should be unreachable as the grammar guarantees the prefix
+                    ""
+                }
+            };
             let parts: Vec<String> = without
                 .split('.')
                 .filter(|p| !p.is_empty())

--- a/crates/moqtail-core/tests/selector.rs
+++ b/crates/moqtail-core/tests/selector.rs
@@ -130,3 +130,8 @@ fn parse_json_predicate() {
         }
     );
 }
+
+#[test]
+fn error_on_malformed_json_prefix() {
+    assert!(compile("/foo[json.temp>30]").is_err());
+}


### PR DESCRIPTION
## Summary
- Use `strip_prefix` for JSON field parsing and guard against missing prefix
- Add test verifying malformed JSON prefixes are rejected

## Testing
- `cargo test -p moqtail-core`


------
https://chatgpt.com/codex/tasks/task_e_689f4c9e1a708328ab505f71df0e4b89