### PR TITLE
Support floating point numbers in selector predicates

### DIFF
--- a/crates/moqtail-core/src/ast.rs
+++ b/crates/moqtail-core/src/ast.rs
@@ -27,20 +27,20 @@ pub enum Operator {
     Ge,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum Value {
-    Number(i64),
+    Number(f64),
     Bool(bool),
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq)]
 pub struct Predicate {
     pub field: Field,
     pub op: Operator,
     pub value: Value,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq)]
 pub struct Step {
     pub axis: Axis,
     pub segment: Segment,
@@ -55,7 +55,7 @@ pub enum Stage {
     Count,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq)]
 pub struct Selector {
     pub steps: Vec<Step>,
     pub stages: Vec<Stage>,

--- a/crates/moqtail-core/src/matcher.rs
+++ b/crates/moqtail-core/src/matcher.rs
@@ -186,7 +186,7 @@ impl Matcher {
                     Some(v) => v,
                     None => return false,
                 };
-                if let Ok(num) = hv.parse::<i64>() {
+                if let Ok(num) = hv.parse::<f64>() {
                     Value::Number(num)
                 } else {
                     Value::Bool(hv == "true")
@@ -205,7 +205,7 @@ impl Matcher {
                 }
                 if let Some(b) = cur.as_bool() {
                     Value::Bool(b)
-                } else if let Some(n) = cur.as_i64() {
+                } else if let Some(n) = cur.as_f64() {
                     Value::Number(n)
                 } else {
                     return false;

--- a/crates/moqtail-core/src/parser.rs
+++ b/crates/moqtail-core/src/parser.rs
@@ -10,6 +10,8 @@ pub enum Error {
     Pest(#[from] pest::error::Error<Rule>),
     #[error(transparent)]
     ParseInt(#[from] std::num::ParseIntError),
+    #[error(transparent)]
+    ParseFloat(#[from] std::num::ParseFloatError),
     #[error("missing selector")]
     MissingSelector,
     #[error("missing axis")]
@@ -113,7 +115,7 @@ pub fn compile(input: &str) -> Result<Selector, Error> {
                     let value_pair = pred_inner.next().ok_or(Error::MissingValue)?;
                     let value_inner = value_pair.into_inner().next().ok_or(Error::MissingValue)?;
                     let value = match value_inner.as_rule() {
-                        Rule::number => Value::Number(value_inner.as_str().parse::<i64>()?),
+                        Rule::number => Value::Number(value_inner.as_str().parse::<f64>()?),
                         Rule::boolean => Value::Bool(value_inner.as_str() == "true"),
                         _ => return Err(Error::InvalidValue),
                     };

--- a/crates/moqtail-core/src/selector.pest
+++ b/crates/moqtail-core/src/selector.pest
@@ -20,7 +20,7 @@ wildcard = { "+" | "#" }
 
 ident = { (ASCII_ALPHANUMERIC | "_" | "-")+ }
 
-number = { ASCII_DIGIT+ }
+number = { "-"? ~ ASCII_DIGIT+ ~ ("." ~ ASCII_DIGIT+)? }
 
 boolean = { "true" | "false" }
 

--- a/crates/moqtail-core/tests/predicate.rs
+++ b/crates/moqtail-core/tests/predicate.rs
@@ -26,3 +26,28 @@ fn json_predicate_match() {
     let m = Matcher::new(sel);
     assert!(m.matches(&msg));
 }
+
+#[test]
+fn header_predicate_negative_fractional() {
+    let sel = compile("/msg[temp<=-1.5]").unwrap();
+    let msg = Message {
+        topic: "",
+        headers: HashMap::from([("temp".to_string(), "-1.5".to_string())]),
+        payload: None,
+    };
+    let m = Matcher::new(sel);
+    assert!(m.matches(&msg));
+}
+
+#[test]
+fn json_predicate_fractional() {
+    let sel = compile("/foo[json$.temp>=32.5]").unwrap();
+    let payload = json!({"temp": 33.1});
+    let msg = Message {
+        topic: "foo",
+        headers: HashMap::new(),
+        payload: Some(payload),
+    };
+    let m = Matcher::new(sel);
+    assert!(m.matches(&msg));
+}

--- a/crates/moqtail-core/tests/selector.rs
+++ b/crates/moqtail-core/tests/selector.rs
@@ -15,7 +15,7 @@ fn parse_selector_with_predicate() {
                 predicates: vec![Predicate {
                     field: Field::Header("bar".into()),
                     op: Operator::Eq,
-                    value: Value::Number(1)
+                    value: Value::Number(1.0)
                 }],
             }],
             stages: vec![],
@@ -97,7 +97,7 @@ fn parse_header_axis() {
                     predicates: vec![Predicate {
                         field: Field::Header("qos".into()),
                         op: Operator::Le,
-                        value: Value::Number(1)
+                        value: Value::Number(1.0)
                     }],
                 },
                 Step {
@@ -123,7 +123,27 @@ fn parse_json_predicate() {
                 predicates: vec![Predicate {
                     field: Field::Json(vec!["temp".into()]),
                     op: Operator::Gt,
-                    value: Value::Number(30)
+                    value: Value::Number(30.0)
+                }],
+            }],
+            stages: vec![],
+        }
+    );
+}
+
+#[test]
+fn parse_negative_fractional_number() {
+    let sel = compile("/foo[bar=-1.5]").unwrap();
+    assert_eq!(
+        sel,
+        Selector {
+            steps: vec![Step {
+                axis: Axis::Child,
+                segment: Segment::Literal("foo".into()),
+                predicates: vec![Predicate {
+                    field: Field::Header("bar".into()),
+                    op: Operator::Eq,
+                    value: Value::Number(-1.5)
                 }],
             }],
             stages: vec![],


### PR DESCRIPTION
## Summary
- allow optional minus signs and decimal parts in selector `number` tokens
- parse `Value::Number` as `f64` and compare predicates using floating point values
- add tests for negative and fractional numbers

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689f4c9bc22483288d95909ec5b4436b