### PR TITLE
Add string predicate support

### DIFF
--- a/crates/moqtail-core/src/ast.rs
+++ b/crates/moqtail-core/src/ast.rs
@@ -27,10 +27,11 @@ pub enum Operator {
     Ge,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Value {
     Number(i64),
     Bool(bool),
+    Str(String),
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -124,5 +125,6 @@ fn display_value(val: &Value) -> String {
     match val {
         Value::Number(n) => n.to_string(),
         Value::Bool(b) => b.to_string(),
+        Value::Str(s) => format!("\"{}\"", s),
     }
 }

--- a/crates/moqtail-core/src/matcher.rs
+++ b/crates/moqtail-core/src/matcher.rs
@@ -188,8 +188,10 @@ impl Matcher {
                 };
                 if let Ok(num) = hv.parse::<i64>() {
                     Value::Number(num)
-                } else {
+                } else if hv == "true" || hv == "false" {
                     Value::Bool(hv == "true")
+                } else {
+                    Value::Str(hv.clone())
                 }
             }
             Field::Json(ref path) => {
@@ -207,6 +209,8 @@ impl Matcher {
                     Value::Bool(b)
                 } else if let Some(n) = cur.as_i64() {
                     Value::Number(n)
+                } else if let Some(s) = cur.as_str() {
+                    Value::Str(s.to_string())
                 } else {
                     return false;
                 }
@@ -226,6 +230,10 @@ impl Matcher {
                 Operator::Ge => l >= r,
             },
             (Value::Bool(l), Value::Bool(r)) => match op {
+                Operator::Eq => l == r,
+                _ => false,
+            },
+            (Value::Str(l), Value::Str(r)) => match op {
                 Operator::Eq => l == r,
                 _ => false,
             },

--- a/crates/moqtail-core/src/parser.rs
+++ b/crates/moqtail-core/src/parser.rs
@@ -115,6 +115,10 @@ pub fn compile(input: &str) -> Result<Selector, Error> {
                     let value = match value_inner.as_rule() {
                         Rule::number => Value::Number(value_inner.as_str().parse::<i64>()?),
                         Rule::boolean => Value::Bool(value_inner.as_str() == "true"),
+                        Rule::string => {
+                            let s = value_inner.as_str();
+                            Value::Str(s[1..s.len() - 1].to_string())
+                        }
                         _ => return Err(Error::InvalidValue),
                     };
 

--- a/crates/moqtail-core/src/selector.pest
+++ b/crates/moqtail-core/src/selector.pest
@@ -24,7 +24,9 @@ number = { ASCII_DIGIT+ }
 
 boolean = { "true" | "false" }
 
-value = { boolean | number }
+string = { "\"" ~ (!"\"" ~ ANY)* ~ "\"" }
+
+value = { boolean | number | string }
 
 stage = { pipe ~ function }
 pipe = _{ "|>" }

--- a/crates/moqtail-core/tests/predicate.rs
+++ b/crates/moqtail-core/tests/predicate.rs
@@ -26,3 +26,28 @@ fn json_predicate_match() {
     let m = Matcher::new(sel);
     assert!(m.matches(&msg));
 }
+
+#[test]
+fn header_predicate_string_match() {
+    let sel = compile("/msg[ty=\"text\"]").unwrap();
+    let msg = Message {
+        topic: "",
+        headers: HashMap::from([("ty".to_string(), "text".to_string())]),
+        payload: None,
+    };
+    let m = Matcher::new(sel);
+    assert!(m.matches(&msg));
+}
+
+#[test]
+fn json_predicate_string_match() {
+    let sel = compile("/foo[json$.status=\"ok\"]").unwrap();
+    let payload = json!({"status": "ok"});
+    let msg = Message {
+        topic: "foo",
+        headers: HashMap::new(),
+        payload: Some(payload),
+    };
+    let m = Matcher::new(sel);
+    assert!(m.matches(&msg));
+}


### PR DESCRIPTION
## Summary
- support string values in selectors and predicates
- extend parser and matcher for string comparisons
- add tests for header and JSON string predicates

## Testing
- `cargo test -p moqtail-core`


------
https://chatgpt.com/codex/tasks/task_e_689f4c991edc83289892c271d2b65e5f