### PR TITLE
fix build by removing Copy from Value

### DIFF
--- a/crates/moqtail-core/src/ast.rs
+++ b/crates/moqtail-core/src/ast.rs
@@ -27,7 +27,11 @@ pub enum Operator {
     Ge,
 }
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+// Value can represent numbers, booleans or strings.  The `Str` variant owns a
+// `String`, which cannot implement the `Copy` trait.  Deriving `Copy` for this
+// enum therefore causes compilation to fail.  We only derive `Clone` to allow
+// duplication when needed while keeping the type non-`Copy`.
+#[derive(Debug, PartialEq, Clone)]
 pub enum Value {
     Number(f64),
     Bool(bool),


### PR DESCRIPTION
## Summary
- avoid deriving Copy for Value enum to handle String variant

## Testing
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689fb2225c888328b2e88f8c3969b53a