### PR TITLE
Standardize connection failure message

### DIFF
--- a/crates/moqtail-cli/src/main.rs
+++ b/crates/moqtail-cli/src/main.rs
@@ -49,7 +49,7 @@ fn main() {
 
                 let (client, mut connection) = Client::new(mqttoptions, 10);
                 if let Err(e) = client.subscribe(selector.to_string(), QoS::AtMostOnce) {
-                    eprintln!("Failed to subscribe: {e}");
+                    eprintln!("Connection error: {e}");
                     std::process::exit(1);
                 }
 


### PR DESCRIPTION
## Summary
- ensure moqtail-cli prints `Connection error` when subscriptions fail to connect

## Testing
- `cargo test -p moqtail-cli -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_689fca4f0f48832890d436f2d62e5280