### PR TITLE
chore: add rustfmt pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: rustfmt
+        name: rustfmt
+        entry: rustfmt
+        language: system
+        types: [rust]
+        args: ["--edition", "2021"]


### PR DESCRIPTION
## Summary
- run `rustfmt` on staged Rust sources via pre-commit

## Testing
- `pre-commit run --files crates/moqtail-core/src/lib.rs`
- `cargo test --workspace --exclude moqtail-python --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68a0fcadfb088328a8031b5b2e7b49dc