### PR TITLE
docs: add pipeline stages documentation

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -3,6 +3,7 @@
 - [Introduction](README.md)
 - [Header Predicates](header_predicates.md)
 - [JSON Payload Selectors](json_payload_selectors.md)
+- [Pipeline Stages](pipeline_stages.md)
 
 - [Cookbook]
   - [Filtering Retained QoS≤1 Messages](../cookbook/filter_retained_qos1.md)

--- a/docs/src/pipeline_stages.md
+++ b/docs/src/pipeline_stages.md
@@ -1,0 +1,45 @@
+# Pipeline Stages
+
+Selectors can transform and aggregate matched messages using a Unix-like pipeline syntax. Each stage is appended with `|>` and operates on the output of the previous stage.
+
+## `window(duration)`
+
+Groups messages into tumbling time windows. The duration is specified in seconds.
+
+```bash
+$ moqtail sub "//sensor |> window(60s)"
+```
+
+## `sum(field)`
+
+Adds the numeric values of the given field across all messages in the current window.
+
+```bash
+$ moqtail sub "//sensor |> window(60s) |> sum(json$.value)"
+```
+
+## `avg(field)`
+
+Computes the average of a numeric field across messages in the window.
+
+```bash
+$ moqtail sub "//sensor |> window(60s) |> avg(json$.value)"
+```
+
+## `count()`
+
+Counts the number of messages in the window.
+
+```bash
+$ moqtail sub "//sensor |> window(5m) |> count()"
+```
+
+## Chaining Stages
+
+Stages can be chained to build multi-step analytics.
+
+```bash
+$ moqtail sub "//sensor |> window(30s) |> avg(json$.value) |> window(5m) |> count()"
+```
+
+This subscription computes 30‑second averages of sensor values and then counts how many such averages fall within each five‑minute window.


### PR DESCRIPTION
## Summary
- document pipeline stages with examples
- link pipeline stages page in book summary

## Testing
- `pre-commit run --files docs/src/SUMMARY.md docs/src/pipeline_stages.md`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a2699d18088328bccf5c6329a42b99