### PR TITLE
Add auth and TLS options to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ $ moqtail sub "//sensor[@type='temp'][json$.value > 30]"
 # Use a different broker address
 $ moqtail sub --host broker.example.com --port 1884 "//sensor"
 
+# Authenticate over TLS
+$ moqtail sub --username alice --password secret --tls "//sensor"
+
 # Only check that the query compiles
 $ moqtail sub --dry-run "//sensor"
 ```

--- a/crates/moqtail-cli/tests/cli.rs
+++ b/crates/moqtail-cli/tests/cli.rs
@@ -21,7 +21,19 @@ fn sub_errors_on_invalid_selector() {
 fn sub_errors_on_connection_failure() {
     let mut cmd = Command::cargo_bin("moqtail-cli").unwrap();
     cmd.arg("sub").arg("/foo").arg("--host").arg("invalid");
-    cmd.assert()
-        .failure()
-        .stderr(contains("Connection error"));
+    cmd.assert().failure().stderr(contains("Connection error"));
+}
+
+#[test]
+fn sub_accepts_auth_and_tls_flags() {
+    let mut cmd = Command::cargo_bin("moqtail-cli").unwrap();
+    cmd.arg("sub")
+        .arg("/foo")
+        .arg("--username")
+        .arg("user")
+        .arg("--password")
+        .arg("pass")
+        .arg("--tls")
+        .arg("--dry-run");
+    cmd.assert().success().stdout(contains("/foo"));
 }


### PR DESCRIPTION
## Summary
- add --username, --password and --tls flags to `moqtail sub`
- configure `MqttOptions` with credentials and optional TLS
- document new flags and test CLI parsing

## Testing
- `cargo fmt`
- `cargo test -p moqtail-cli`


------
https://chatgpt.com/codex/tasks/task_e_68a2699addcc8328a960b7b7cef38b39