### PR TITLE
Return error when JSON predicate field is missing

### DIFF
--- a/crates/moqtail-core/tests/predicate.rs
+++ b/crates/moqtail-core/tests/predicate.rs
@@ -52,3 +52,8 @@ fn json_predicate_fractional() {
     let m = Matcher::new(sel);
     assert!(m.matches(&msg));
 }
+
+#[test]
+fn json_predicate_missing_field() {
+    assert!(compile(" /foo[json$>1]").is_err());
+}


### PR DESCRIPTION
## Summary
- Fail parsing JSON field predicates if no field segments are given
- Add regression test ensuring selector compilation errors for missing JSON field

## Testing
- `cargo test` *(fails: this file contains an unclosed delimiter in matcher.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68a49962fb688328bee18f010ba5ce9e