### PR TITLE
Handle partial MQTT credentials in CLI and add tests

### DIFF
--- a/crates/moqtail-cli/src/main.rs
+++ b/crates/moqtail-cli/src/main.rs
@@ -58,11 +58,11 @@ fn main() {
 
                 let mut mqttoptions = MqttOptions::new("moqtail-cli", host, port);
                 mqttoptions.set_keep_alive(Duration::from_secs(5));
-                if username.is_some() || password.is_some() {
-                    mqttoptions.set_credentials(
-                        username.unwrap_or_default(),
-                        password.unwrap_or_default(),
-                    );
+                match (username, password) {
+                    (Some(u), Some(p)) => mqttoptions.set_credentials(u, p),
+                    (Some(u), None) => mqttoptions.set_credentials(u, ""),
+                    (None, Some(p)) => mqttoptions.set_credentials("", p),
+                    (None, None) => {}
                 }
                 if tls {
                     mqttoptions.set_transport(Transport::tls_with_default_config());

--- a/crates/moqtail-cli/tests/cli.rs
+++ b/crates/moqtail-cli/tests/cli.rs
@@ -37,3 +37,22 @@ fn sub_accepts_auth_and_tls_flags() {
         .arg("--dry-run");
     cmd.assert().success().stdout(contains("/foo"));
 }
+
+#[test]
+fn sub_accepts_single_credential_flags() {
+    let mut cmd = Command::cargo_bin("moqtail-cli").unwrap();
+    cmd.arg("sub")
+        .arg("/foo")
+        .arg("--username")
+        .arg("user")
+        .arg("--dry-run");
+    cmd.assert().success().stdout(contains("/foo"));
+
+    let mut cmd = Command::cargo_bin("moqtail-cli").unwrap();
+    cmd.arg("sub")
+        .arg("/foo")
+        .arg("--password")
+        .arg("pass")
+        .arg("--dry-run");
+    cmd.assert().success().stdout(contains("/foo"));
+}


### PR DESCRIPTION
## Summary
- only set MQTT credentials when username or password is provided, defaulting the missing field to an empty string
- test CLI with username-only and password-only authentication flags

## Testing
- `cargo test -p moqtail-cli` *(fails: this file contains an unclosed delimiter in crates/moqtail-core/src/matcher.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68a4996107e48328af45a42fd4a14542