### PR TITLE
Escape string values and test round trips

### DIFF
--- a/crates/moqtail-core/src/ast.rs
+++ b/crates/moqtail-core/src/ast.rs
@@ -129,6 +129,6 @@ fn display_value(val: &Value) -> String {
     match val {
         Value::Number(n) => n.to_string(),
         Value::Bool(b) => b.to_string(),
-        Value::Str(s) => format!("\"{}\"", s),
+        Value::Str(s) => serde_json::to_string(s).unwrap(),
     }
 }

--- a/crates/moqtail-core/src/matcher.rs
+++ b/crates/moqtail-core/src/matcher.rs
@@ -334,7 +334,9 @@ mod tests {
         };
         let field = Field::Json(vec!["temp".into()]);
         assert_eq!(Matcher::extract_field(&field, &msg), Some(21.0));
+    }
 
+    #[test]
     fn process_sum_without_window() {
         let sel = compile("/sensor |> sum(temp)").unwrap();
         let mut m = Matcher::new(sel);
@@ -473,6 +475,5 @@ mod tests {
             payload: None,
         };
         assert_eq!(m.process(&msg3), Some(2.0));
-
     }
 }

--- a/crates/moqtail-core/src/parser.rs
+++ b/crates/moqtail-core/src/parser.rs
@@ -119,7 +119,9 @@ pub fn compile(input: &str) -> Result<Selector, Error> {
                         Rule::boolean => Value::Bool(value_inner.as_str() == "true"),
                         Rule::string => {
                             let s = value_inner.as_str();
-                            Value::Str(s[1..s.len() - 1].to_string())
+                            let parsed: String =
+                                serde_json::from_str(s).map_err(|_| Error::InvalidValue)?;
+                            Value::Str(parsed)
                         }
                         _ => return Err(Error::InvalidValue),
                     };

--- a/crates/moqtail-core/src/selector.pest
+++ b/crates/moqtail-core/src/selector.pest
@@ -24,7 +24,7 @@ number = { "-"? ~ ASCII_DIGIT+ ~ ("." ~ ASCII_DIGIT+)? }
 
 boolean = { "true" | "false" }
 
-string = { "\"" ~ (!"\"" ~ ANY)* ~ "\"" }
+string = { "\"" ~ ( "\\" ~ ANY | !"\"" ~ ANY )* ~ "\"" }
 
 value = { boolean | number | string }
 

--- a/crates/moqtail-core/tests/display.rs
+++ b/crates/moqtail-core/tests/display.rs
@@ -1,3 +1,4 @@
+use moqtail_core::ast::{Axis, Field, Operator, Predicate, Segment, Selector, Step, Value};
 use moqtail_core::compile;
 
 #[test]
@@ -11,6 +12,44 @@ fn selector_display_roundtrip() {
 fn selector_display_with_predicate() {
     let selector = compile("/foo[bar=1]").unwrap();
     assert_eq!(selector.to_string(), "/foo[bar=1]");
+}
+
+#[test]
+fn selector_display_with_quoted_string() {
+    let selector = Selector {
+        steps: vec![Step {
+            axis: Axis::Child,
+            segment: Segment::Literal("foo".into()),
+            predicates: vec![Predicate {
+                field: Field::Header("bar".into()),
+                op: Operator::Eq,
+                value: Value::Str("qu\"ote".into()),
+            }],
+        }],
+        stages: vec![],
+    };
+    let display = selector.to_string();
+    let reparsed = compile(&display).unwrap();
+    assert_eq!(reparsed, selector);
+}
+
+#[test]
+fn selector_display_with_backslash() {
+    let selector = Selector {
+        steps: vec![Step {
+            axis: Axis::Child,
+            segment: Segment::Literal("foo".into()),
+            predicates: vec![Predicate {
+                field: Field::Header("bar".into()),
+                op: Operator::Eq,
+                value: Value::Str("a\\b".into()),
+            }],
+        }],
+        stages: vec![],
+    };
+    let display = selector.to_string();
+    let reparsed = compile(&display).unwrap();
+    assert_eq!(reparsed, selector);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- escape string predicate values using `serde_json`
- parse escaped strings and update grammar to support them
- add roundtrip tests for quotes and backslashes
- fix matcher tests module closing brace

## Testing
- `cargo test -p moqtail-core`


------
https://chatgpt.com/codex/tasks/task_e_68a4995f724c8328a914cdbb6c97895b