### PR TITLE
chore(js): add @napi-rs/cli dev dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,7 @@ This guide explains the project layout, coding standards, and pull‑request wor
 
 * **Rust** 1.78+ (install via [`rustup`](https://rustup.rs)).
 * **Node.js** 20+ (only if you hack on the JS bindings).
+* [`@napi-rs/cli`](https://github.com/Brooooooklyn/napi-rs/tree/main/cli) (required for building the JS bindings).
 * **Python** 3.12+ with development headers (only for the optional Python bindings).
 * **GNU Make** (used by `Makefile` shortcuts).
 * **Docker** (optional, for broker plugin testing).

--- a/bindings/js/README.md
+++ b/bindings/js/README.md
@@ -4,14 +4,17 @@ These bindings expose `moqtail-core` to Node.js using [napi-rs](https://napi.rs/
 
 ## Building
 
-1. Install the `napi` CLI:
-   ```bash
-   npm install -g @napi-rs/cli
-   ```
-2. Build the addon (runs automatically on `npm install`):
-   ```bash
-   npm install
-   ```
+`@napi-rs/cli` is listed under `devDependencies`. Running `npm install` pulls it in and builds the addon:
+
+```bash
+npm install
+```
+
+You can also install the CLI globally if you prefer:
+
+```bash
+npm install -g @napi-rs/cli
+```
 
 The resulting `moqtail-js.node` binary will be placed next to `index.js` and can be required as:
 

--- a/bindings/js/package.json
+++ b/bindings/js/package.json
@@ -5,5 +5,8 @@
   "files": ["index.js", "moqtail-js.node"],
   "scripts": {
     "install": "napi build --release"
+  },
+  "devDependencies": {
+    "@napi-rs/cli": "^2"
   }
 }


### PR DESCRIPTION
## Summary
- include `@napi-rs/cli` under JS dev dependencies
- document `@napi-rs/cli` in contributing guide and JS README

## Testing
- `npm install --no-package-lock`

------
https://chatgpt.com/codex/tasks/task_e_68b0ec27f2cc8328baa9413abdb13e39