### PR TITLE
Exclude moqtail-js from check target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 check:
 	cargo fmt --all -- --check
-	cargo clippy --workspace --exclude moqtail-python --all-targets -- -D warnings
-	cargo test --workspace --exclude moqtail-python
+	cargo clippy --workspace --exclude moqtail-python --exclude moqtail-js --all-targets -- -D warnings
+	cargo test --workspace --exclude moqtail-python --exclude moqtail-js
 
 .PHONY: check


### PR DESCRIPTION
## Summary
- prevent `moqtail-js` from running during `cargo clippy` and `cargo test` in `make check`

## Testing
- `make check` *(fails: error: could not compile `moqtail-core` (lib) due to 6 previous errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ec205d4c8328a827eefbcbf6116b