### PR TITLE
Make JS bindings optional via feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,5 @@ default-members = [
     "xtask",
     "crates/moqtail-core",
     "crates/moqtail-cli",
-    "bindings/js",
 ]
 resolver = "2"

--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ MoQTail keeps MQTT’s 2‑byte fixed header intact — **zero protocol bloat** 
 
    * `moqtail-core` – DSL parser, AST, matcher engine
    * **Broker plugins** – adapters for Mosquitto and EMQX under `plugins/`
-   * `moqtail-cli` – *tail -f* style command‑line client
-   * `moqtail-js` / `moqtail-py` – thin client helpers for web & Python apps
+     * `moqtail-cli` – *tail -f* style command‑line client
+    * `moqtail-js` / `moqtail-py` – thin client helpers for web & Python apps
+      * JavaScript bindings are gated behind the `js-bindings` Cargo feature and are not
+        built by default. Enable them with `cargo build -p moqtail-js --features js-bindings`.
 4. **FOSS‑friendly** – Dual‑licensed under MIT / Apache 2.0 to play nicely with both hobby and commercial adopters.
 
 ---

--- a/bindings/js/Cargo.toml
+++ b/bindings/js/Cargo.toml
@@ -6,8 +6,13 @@ license = "MIT OR Apache-2.0"
 
 [lib]
 crate-type = ["cdylib"]
+required-features = ["js-bindings"]
 
 [dependencies]
 moqtail-core = { path = "../../crates/moqtail-core" }
 napi = { version = "2", features = ["napi6"] }
 napi-derive = "2"
+
+[features]
+default = []
+js-bindings = []


### PR DESCRIPTION
## Summary
- exclude `bindings/js` from default workspace members
- gate JavaScript bindings behind a `js-bindings` Cargo feature
- document how to enable the JS bindings

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude moqtail-python --all-targets -- -D warnings` *(fails: large enum variant in `moqtail-core`)*
- `cargo test --workspace --exclude moqtail-python` *(fails: compile error in `moqtail-cli`)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ec1158748328a716a0ed19ea2480