### PR TITLE
Fix clippy warnings in parser and tests

### DIFF
--- a/crates/moqtail-core/tests/pipeline.rs
+++ b/crates/moqtail-core/tests/pipeline.rs
@@ -62,7 +62,7 @@ fn count_pipeline() {
 
     let msg2 = Message {
         topic: "sensor",
-        headers: headers,
+        headers,
         payload: None,
     };
     assert_eq!(m.process(&msg2), Some(2.0));


### PR DESCRIPTION
## Summary
- box Pest errors to reduce Error enum size
- simplify JSON field parsing
- remove redundant struct field names in tests

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_68b0f90ea820832898eb2864385792b6