### PR TITLE
Handle non-JSON payloads in mosquitto plugin

### DIFF
--- a/plugins/mosquitto/src/lib.rs
+++ b/plugins/mosquitto/src/lib.rs
@@ -49,7 +49,7 @@ extern "C" fn on_message(_: c_int, event_data: *mut c_void, userdata: *mut c_voi
                 Ok(j) => Some(j),
                 Err(e) => {
                     eprintln!("[MoQTail] payload JSON parse error: {}", e);
-                    return MOSQ_ERR_PLUGIN_DEFER;
+                    None
                 }
             }
         } else {
@@ -219,7 +219,7 @@ mod tests {
             msg.payloadlen = bad_payload.as_bytes().len() as u32;
             assert_eq!(
                 cb(MOSQ_EVT_MESSAGE, &mut msg as *mut _ as *mut c_void, ctx),
-                MOSQ_ERR_PLUGIN_DEFER
+                MOSQ_ERR_SUCCESS
             );
 
             mosquitto_plugin_cleanup(std::ptr::null_mut(), userdata, std::ptr::null_mut(), 0);

--- a/plugins/mosquitto/tests/filter.rs
+++ b/plugins/mosquitto/tests/filter.rs
@@ -1,12 +1,16 @@
 use std::ffi::CString;
 use std::os::raw::{c_char, c_int, c_void};
 extern crate moqtail_mosquitto;
-use moqtail_mosquitto::{mosquitto_opt, mosquitto_evt_message, mosquitto_plugin_init, mosquitto_plugin_cleanup};
+use moqtail_mosquitto::{
+    mosquitto_evt_message, mosquitto_opt, mosquitto_plugin_cleanup, mosquitto_plugin_init,
+};
 
 const MOSQ_ERR_PLUGIN_DEFER: c_int = 17;
 
-
-static mut REGISTERED: Option<(extern "C" fn(c_int, *mut c_void, *mut c_void) -> c_int, *mut c_void)> = None;
+static mut REGISTERED: Option<(
+    extern "C" fn(c_int, *mut c_void, *mut c_void) -> c_int,
+    *mut c_void,
+)> = None;
 
 #[no_mangle]
 unsafe extern "C" fn mosquitto_callback_register(
@@ -33,16 +37,21 @@ unsafe extern "C" fn mosquitto_callback_unregister(
     0
 }
 
-
 #[test]
 fn filter_integration() {
     unsafe {
         let key = CString::new("selector").unwrap();
-        let val = CString::new("/foo/+" ).unwrap();
-        let mut opt = mosquitto_opt { key: key.as_ptr() as *mut c_char, value: val.as_ptr() as *mut c_char };
+        let val = CString::new("/foo/+").unwrap();
+        let mut opt = mosquitto_opt {
+            key: key.as_ptr() as *mut c_char,
+            value: val.as_ptr() as *mut c_char,
+        };
         let mut userdata: *mut c_void = std::ptr::null_mut();
 
-        assert_eq!(mosquitto_plugin_init(std::ptr::null_mut(), &mut userdata, &mut opt, 1), 0);
+        assert_eq!(
+            mosquitto_plugin_init(std::ptr::null_mut(), &mut userdata, &mut opt, 1),
+            0
+        );
         let (cb, ctx) = REGISTERED.expect("callback registered");
 
         let topic1 = CString::new("foo/bar").unwrap();
@@ -64,7 +73,10 @@ fn filter_integration() {
 
         let topic2 = CString::new("baz/qux").unwrap();
         msg.topic = topic2.as_ptr() as *mut c_char;
-        assert_eq!(cb(7, &mut msg as *mut _ as *mut c_void, ctx), MOSQ_ERR_PLUGIN_DEFER);
+        assert_eq!(
+            cb(7, &mut msg as *mut _ as *mut c_void, ctx),
+            MOSQ_ERR_PLUGIN_DEFER
+        );
 
         mosquitto_plugin_cleanup(std::ptr::null_mut(), userdata, std::ptr::null_mut(), 0);
         assert!(REGISTERED.is_none());
@@ -76,21 +88,28 @@ fn header_filter() {
     unsafe {
         let key = CString::new("selector").unwrap();
         let val = CString::new("/msg[qos<=1]").unwrap();
-        let mut opt = mosquitto_opt { key: key.as_ptr() as *mut c_char, value: val.as_ptr() as *mut c_char };
+        let mut opt = mosquitto_opt {
+            key: key.as_ptr() as *mut c_char,
+            value: val.as_ptr() as *mut c_char,
+        };
         let mut userdata: *mut c_void = std::ptr::null_mut();
 
-        assert_eq!(mosquitto_plugin_init(std::ptr::null_mut(), &mut userdata, &mut opt, 1), 0);
+        assert_eq!(
+            mosquitto_plugin_init(std::ptr::null_mut(), &mut userdata, &mut opt, 1),
+            0
+        );
         let (cb, ctx) = REGISTERED.expect("callback registered");
 
         let topic = CString::new("").unwrap();
+        let bad_payload = CString::new("not json").unwrap();
         let mut msg = mosquitto_evt_message {
             future: std::ptr::null_mut(),
             client: std::ptr::null_mut(),
             topic: topic.as_ptr() as *mut c_char,
-            payload: std::ptr::null_mut(),
+            payload: bad_payload.as_ptr() as *mut c_void,
             properties: std::ptr::null_mut(),
             reason_string: std::ptr::null_mut(),
-            payloadlen: 0,
+            payloadlen: bad_payload.as_bytes().len() as u32,
             qos: 0,
             reason_code: 0,
             retain: false,
@@ -100,7 +119,10 @@ fn header_filter() {
         assert_eq!(cb(7, &mut msg as *mut _ as *mut c_void, ctx), 0);
 
         msg.qos = 2;
-        assert_eq!(cb(7, &mut msg as *mut _ as *mut c_void, ctx), MOSQ_ERR_PLUGIN_DEFER);
+        assert_eq!(
+            cb(7, &mut msg as *mut _ as *mut c_void, ctx),
+            MOSQ_ERR_PLUGIN_DEFER
+        );
 
         mosquitto_plugin_cleanup(std::ptr::null_mut(), userdata, std::ptr::null_mut(), 0);
         assert!(REGISTERED.is_none());
@@ -112,10 +134,16 @@ fn payload_filter() {
     unsafe {
         let key = CString::new("selector").unwrap();
         let val = CString::new("/foo[json$.temp>30]").unwrap();
-        let mut opt = mosquitto_opt { key: key.as_ptr() as *mut c_char, value: val.as_ptr() as *mut c_char };
+        let mut opt = mosquitto_opt {
+            key: key.as_ptr() as *mut c_char,
+            value: val.as_ptr() as *mut c_char,
+        };
         let mut userdata: *mut c_void = std::ptr::null_mut();
 
-        assert_eq!(mosquitto_plugin_init(std::ptr::null_mut(), &mut userdata, &mut opt, 1), 0);
+        assert_eq!(
+            mosquitto_plugin_init(std::ptr::null_mut(), &mut userdata, &mut opt, 1),
+            0
+        );
         let (cb, ctx) = REGISTERED.expect("callback registered");
 
         let topic = CString::new("foo").unwrap();
@@ -139,7 +167,10 @@ fn payload_filter() {
         let payload2 = CString::new("{\"temp\":25}").unwrap();
         msg.payload = payload2.as_ptr() as *mut c_void;
         msg.payloadlen = payload2.as_bytes().len() as u32;
-        assert_eq!(cb(7, &mut msg as *mut _ as *mut c_void, ctx), MOSQ_ERR_PLUGIN_DEFER);
+        assert_eq!(
+            cb(7, &mut msg as *mut _ as *mut c_void, ctx),
+            MOSQ_ERR_PLUGIN_DEFER
+        );
 
         mosquitto_plugin_cleanup(std::ptr::null_mut(), userdata, std::ptr::null_mut(), 0);
         assert!(REGISTERED.is_none());

--- a/plugins/mosquitto/tests/malformed.rs
+++ b/plugins/mosquitto/tests/malformed.rs
@@ -5,8 +5,6 @@ use moqtail_mosquitto::{
     mosquitto_evt_message, mosquitto_opt, mosquitto_plugin_cleanup, mosquitto_plugin_init,
 };
 
-const MOSQ_ERR_PLUGIN_DEFER: c_int = 17;
-
 static mut REGISTERED: Option<(
     extern "C" fn(c_int, *mut c_void, *mut c_void) -> c_int,
     *mut c_void,
@@ -70,7 +68,7 @@ fn malformed_json() {
             future2: [std::ptr::null_mut(); 4],
         };
 
-        assert_eq!(cb(7, &mut msg as *mut _ as *mut c_void, ctx), MOSQ_ERR_PLUGIN_DEFER);
+        assert_eq!(cb(7, &mut msg as *mut _ as *mut c_void, ctx), 0);
 
         mosquitto_plugin_cleanup(std::ptr::null_mut(), userdata, std::ptr::null_mut(), 0);
         assert!(REGISTERED.is_none());


### PR DESCRIPTION
## Summary
- allow mosquitto plugin to continue when payload JSON parsing fails
- exercise matching with non-JSON payloads via header and topic predicates

## Testing
- `cargo test -p moqtail-mosquitto`


------
https://chatgpt.com/codex/tasks/task_e_68b1e55ed6a08328952d5ee1988c488c