### PR TITLE
Use expect for string serialization in ast

### DIFF
--- a/crates/moqtail-core/src/ast.rs
+++ b/crates/moqtail-core/src/ast.rs
@@ -129,6 +129,6 @@ fn display_value(val: &Value) -> String {
     match val {
         Value::Number(n) => n.to_string(),
         Value::Bool(b) => b.to_string(),
-        Value::Str(s) => serde_json::to_string(s).unwrap(),
+        Value::Str(s) => serde_json::to_string(s).expect("string serialization cannot fail"),
     }
 }


### PR DESCRIPTION
## Summary
- Replace `unwrap` with `expect` when serializing strings in `display_value`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c1f82d8c808328ada46e3ace48c87e