### PR TITLE
Handle empty topic segments in matcher

### DIFF
--- a/crates/moqtail-core/src/matcher.rs
+++ b/crates/moqtail-core/src/matcher.rs
@@ -60,11 +60,7 @@ impl Matcher {
     }
 
     pub fn matches(&self, msg: &Message) -> bool {
-        let segments: Vec<&str> = if msg.topic.is_empty() {
-            Vec::new()
-        } else {
-            msg.topic.split('/').collect()
-        };
+        let segments: Vec<&str> = msg.topic.split('/').filter(|s| !s.is_empty()).collect();
         Self::match_steps(&self.selector.steps, &segments, msg)
     }
 

--- a/crates/moqtail-core/tests/matcher.rs
+++ b/crates/moqtail-core/tests/matcher.rs
@@ -1,0 +1,45 @@
+use std::collections::HashMap;
+
+use moqtail_core::{compile, Matcher, Message};
+
+#[test]
+fn matches_trailing_slash() {
+    let selector = compile("/foo/bar").unwrap();
+    let matcher = Matcher::new(selector);
+
+    let msg = Message {
+        topic: "foo/bar/",
+        headers: HashMap::new(),
+        payload: None,
+    };
+
+    assert!(matcher.matches(&msg));
+}
+
+#[test]
+fn matches_repeated_slashes() {
+    let selector = compile("/foo/bar").unwrap();
+    let matcher = Matcher::new(selector);
+
+    let msg = Message {
+        topic: "foo//bar",
+        headers: HashMap::new(),
+        payload: None,
+    };
+
+    assert!(matcher.matches(&msg));
+}
+
+#[test]
+fn trailing_slash_does_not_match_plus() {
+    let selector = compile("/foo/+").unwrap();
+    let matcher = Matcher::new(selector);
+
+    let msg = Message {
+        topic: "foo/",
+        headers: HashMap::new(),
+        payload: None,
+    };
+
+    assert!(!matcher.matches(&msg));
+}


### PR DESCRIPTION
## Summary
- ignore empty topic segments during matching
- test matching with trailing and repeated slashes

## Testing
- `cargo test -p moqtail-core`


------
https://chatgpt.com/codex/tasks/task_e_68c1f830276c8328b3e257470a9fbb9a