### PR TITLE
feat(core): validate json prefix

### DIFF
--- a/crates/moqtail-core/src/parser.rs
+++ b/crates/moqtail-core/src/parser.rs
@@ -156,8 +156,9 @@ fn parse_field(inner_field: pest::iterators::Pair<Rule>) -> Result<Field, Error>
         Rule::ident => Ok(Field::Header(inner_field.as_str().to_string())),
         Rule::json_field => {
             let text = inner_field.as_str();
-            // The grammar guarantees the prefix, so this unwrap is safe.
-            let without = text.strip_prefix("json$").unwrap_or_default();
+            // The grammar should provide the prefix, but validate to produce a
+            // dedicated error when it is missing.
+            let without = text.strip_prefix("json$").ok_or(Error::MissingField)?;
             let parts: Vec<String> = without
                 .split('.')
                 .filter(|p| !p.is_empty())

--- a/crates/moqtail-core/src/selector.pest
+++ b/crates/moqtail-core/src/selector.pest
@@ -12,7 +12,9 @@ predicate = { "[" ~ field ~ operator ~ value ~ "]" }
 
 field = { json_field | ident }
 
-json_field = { "json$" ~ ("." ~ ident)+ }
+// Allow parsing of malformed prefixes so that the parser can surface a
+// dedicated `MissingField` error when validation fails.
+json_field = { "json" ~ ( "$" ~ ("." ~ ident)* | ("." ~ ident)+ ) }
 
 operator = { "<=" | ">=" | "<" | ">" | "=" }
 

--- a/crates/moqtail-core/tests/predicate.rs
+++ b/crates/moqtail-core/tests/predicate.rs
@@ -1,4 +1,4 @@
-use moqtail_core::{compile, Matcher, Message};
+use moqtail_core::{compile, Error, Matcher, Message};
 use serde_json::json;
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -56,5 +56,6 @@ fn json_predicate_fractional() {
 
 #[test]
 fn json_predicate_missing_field() {
-    assert!(compile(" /foo[json$>1]").is_err());
+    let err = compile("/foo[json$>1]").unwrap_err();
+    assert!(matches!(err, Error::MissingField));
 }

--- a/crates/moqtail-core/tests/selector.rs
+++ b/crates/moqtail-core/tests/selector.rs
@@ -1,6 +1,6 @@
 use moqtail_core::{
     ast::{Axis, Field, Operator, Predicate, Segment, Selector, Step, Value},
-    compile,
+    compile, Error,
 };
 
 #[test]
@@ -153,5 +153,6 @@ fn parse_negative_fractional_number() {
 
 #[test]
 fn error_on_malformed_json_prefix() {
-    assert!(compile("/foo[json.temp>30]").is_err());
+    let err = compile("/foo[json.temp>30]").unwrap_err();
+    assert!(matches!(err, Error::MissingField));
 }


### PR DESCRIPTION
## Summary
- ensure `parse_field` returns `MissingField` when `json$` prefix absent
- relax grammar to parse malformed JSON field prefixes
- add tests checking `MissingField` for bad JSON field syntax

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c1f82f2d148328abcf20fcda445427