### PR TITLE
Handle invalid sum/avg arguments and add regression tests

### DIFF
--- a/crates/moqtail-core/src/parser.rs
+++ b/crates/moqtail-core/src/parser.rs
@@ -193,11 +193,17 @@ fn parse_stage(pair: pest::iterators::Pair<Rule>) -> Result<Stage, Error> {
         }
         "sum" => {
             let a = arg.ok_or(Error::SumRequiresField)?;
+            if a.as_rule() != Rule::field {
+                return Err(Error::SumRequiresField);
+            }
             let field_inner = a.into_inner().next().ok_or(Error::SumRequiresField)?;
             Ok(Stage::Sum(parse_field(field_inner)?))
         }
         "avg" => {
             let a = arg.ok_or(Error::AvgRequiresField)?;
+            if a.as_rule() != Rule::field {
+                return Err(Error::AvgRequiresField);
+            }
             let field_inner = a.into_inner().next().ok_or(Error::AvgRequiresField)?;
             Ok(Stage::Avg(parse_field(field_inner)?))
         }

--- a/crates/moqtail-core/src/selector.pest
+++ b/crates/moqtail-core/src/selector.pest
@@ -33,5 +33,5 @@ value = { boolean | number | string }
 stage = { pipe ~ function }
 pipe = _{ "|>" }
 function = { ident ~ "(" ~ func_arg? ~ ")" }
-func_arg = _{ duration | field }
+func_arg = _{ duration | function | field }
 duration = { number ~ "s" }

--- a/crates/moqtail-core/tests/pipeline.rs
+++ b/crates/moqtail-core/tests/pipeline.rs
@@ -80,3 +80,19 @@ fn sum_missing_field() {
     };
     assert_eq!(m.process(&msg), None);
 }
+
+#[test]
+fn sum_requires_field_argument() {
+    assert!(matches!(
+        compile("/foo |> sum(1s)"),
+        Err(moqtail_core::Error::SumRequiresField)
+    ));
+}
+
+#[test]
+fn avg_requires_field_argument() {
+    assert!(matches!(
+        compile("/foo |> avg(window(5s))"),
+        Err(moqtail_core::Error::AvgRequiresField)
+    ));
+}


### PR DESCRIPTION
## Summary
- validate that sum/avg stages only accept field arguments before parsing them
- allow nested functions in the grammar so invalid arguments can be surfaced as dedicated errors
- add regression tests for selectors with invalid sum/avg arguments

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d82c199be08328a413173980f3e874