### PR TITLE
Handle empty topic segments in matcher

### DIFF
--- a/crates/moqtail-core/src/matcher.rs
+++ b/crates/moqtail-core/src/matcher.rs
@@ -60,7 +60,7 @@ impl Matcher {
     }
 
     pub fn matches(&self, msg: &Message) -> bool {
-        let segments: Vec<&str> = msg.topic.split('/').filter(|s| !s.is_empty()).collect();
+        let segments: Vec<&str> = msg.topic.split('/').collect();
         Self::match_steps(&self.selector.steps, &segments, msg)
     }
 

--- a/crates/moqtail-core/tests/matcher.rs
+++ b/crates/moqtail-core/tests/matcher.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use moqtail_core::{compile, Matcher, Message};
 
 #[test]
-fn matches_trailing_slash() {
+fn trailing_empty_segment_requires_wildcard() {
     let selector = compile("/foo/bar").unwrap();
     let matcher = Matcher::new(selector);
 
@@ -13,11 +13,11 @@ fn matches_trailing_slash() {
         payload: None,
     };
 
-    assert!(matcher.matches(&msg));
+    assert!(!matcher.matches(&msg));
 }
 
 #[test]
-fn matches_repeated_slashes() {
+fn literal_does_not_skip_empty_segments() {
     let selector = compile("/foo/bar").unwrap();
     let matcher = Matcher::new(selector);
 
@@ -27,11 +27,11 @@ fn matches_repeated_slashes() {
         payload: None,
     };
 
-    assert!(matcher.matches(&msg));
+    assert!(!matcher.matches(&msg));
 }
 
 #[test]
-fn trailing_slash_does_not_match_plus() {
+fn plus_matches_empty_segment() {
     let selector = compile("/foo/+").unwrap();
     let matcher = Matcher::new(selector);
 
@@ -41,5 +41,5 @@ fn trailing_slash_does_not_match_plus() {
         payload: None,
     };
 
-    assert!(!matcher.matches(&msg));
+    assert!(matcher.matches(&msg));
 }

--- a/plugins/mosquitto/tests/filter.rs
+++ b/plugins/mosquitto/tests/filter.rs
@@ -71,8 +71,19 @@ fn filter_integration() {
 
         assert_eq!(cb(7, &mut msg as *mut _ as *mut c_void, ctx), 0);
 
-        let topic2 = CString::new("baz/qux").unwrap();
+        let topic2 = CString::new("foo/").unwrap();
         msg.topic = topic2.as_ptr() as *mut c_char;
+        assert_eq!(cb(7, &mut msg as *mut _ as *mut c_void, ctx), 0);
+
+        let topic3 = CString::new("foo//bar").unwrap();
+        msg.topic = topic3.as_ptr() as *mut c_char;
+        assert_eq!(
+            cb(7, &mut msg as *mut _ as *mut c_void, ctx),
+            MOSQ_ERR_PLUGIN_DEFER
+        );
+
+        let topic4 = CString::new("baz/qux").unwrap();
+        msg.topic = topic4.as_ptr() as *mut c_char;
         assert_eq!(
             cb(7, &mut msg as *mut _ as *mut c_void, ctx),
             MOSQ_ERR_PLUGIN_DEFER


### PR DESCRIPTION
## Summary
- ensure matcher retains empty topic levels when splitting MQTT topics
- adjust core matcher tests to reflect MQTT semantics for empty levels
- extend Mosquitto plugin filter test coverage to cover empty topic levels

## Testing
- cargo test -p moqtail-core matcher
- cargo test --manifest-path plugins/mosquitto/Cargo.toml filter_integration


------
https://chatgpt.com/codex/tasks/task_e_68d82c1a6c808328a724e0f9b61e44a7