### PR TITLE
Handle unsigned JSON numbers in matcher

### DIFF
--- a/crates/moqtail-core/src/matcher.rs
+++ b/crates/moqtail-core/src/matcher.rs
@@ -331,8 +331,10 @@ impl Matcher {
                 let v = json_path(msg.payload.as_ref()?, path)?;
                 if let Some(f) = v.as_f64() {
                     Some(f)
+                } else if let Some(i) = v.as_i64() {
+                    Some(i as f64)
                 } else {
-                    v.as_i64().map(|i| i as f64)
+                    v.as_u64().map(|u| u as f64)
                 }
             }
         }

--- a/crates/moqtail-core/tests/pipeline.rs
+++ b/crates/moqtail-core/tests/pipeline.rs
@@ -47,6 +47,21 @@ fn sum_pipeline() {
 }
 
 #[test]
+fn sum_pipeline_large_unsigned() {
+    let sel = compile("/sensor |> window(60s) |> sum(json$.value)").unwrap();
+    let mut m = Matcher::new(sel);
+
+    let headers = HashMap::new();
+
+    let msg = Message {
+        topic: "sensor",
+        headers,
+        payload: Some(json!({"value": u64::MAX})),
+    };
+    assert_eq!(m.process(&msg), Some(u64::MAX as f64));
+}
+
+#[test]
 fn count_pipeline() {
     let sel = compile("/sensor |> window(60s) |> count()").unwrap();
     let mut m = Matcher::new(sel);


### PR DESCRIPTION
## Summary
- extend `Matcher::extract_field` to convert unsigned JSON numbers when floating-point and signed conversions fail
- add a pipeline test covering aggregation of JSON payloads with a large unsigned integer

## Testing
- cargo test -p moqtail-core sum_pipeline_large_unsigned -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68d82c1b21b08328a4175b6cf0b01c1e