### PR TITLE
Support window durations with minutes and hours

### DIFF
--- a/crates/moqtail-core/src/parser.rs
+++ b/crates/moqtail-core/src/parser.rs
@@ -189,7 +189,14 @@ fn parse_stage(pair: pest::iterators::Pair<Rule>) -> Result<Stage, Error> {
             let mut ai = a.into_inner();
             let num_pair = ai.next().ok_or(Error::WindowRequiresDuration)?;
             let num = num_pair.as_str().parse::<u64>()?;
-            Ok(Stage::Window(num))
+            let unit_pair = ai.next().ok_or(Error::WindowRequiresDuration)?;
+            let seconds = match unit_pair.as_str() {
+                "s" => num,
+                "m" => num.checked_mul(60).ok_or(Error::WindowRequiresDuration)?,
+                "h" => num.checked_mul(3600).ok_or(Error::WindowRequiresDuration)?,
+                _ => unreachable!(),
+            };
+            Ok(Stage::Window(seconds))
         }
         "sum" => {
             let a = arg.ok_or(Error::SumRequiresField)?;

--- a/crates/moqtail-core/src/selector.pest
+++ b/crates/moqtail-core/src/selector.pest
@@ -34,4 +34,5 @@ stage = { pipe ~ function }
 pipe = _{ "|>" }
 function = { ident ~ "(" ~ func_arg? ~ ")" }
 func_arg = _{ duration | field }
-duration = { number ~ "s" }
+duration = { number ~ duration_unit }
+duration_unit = { "s" | "m" | "h" }

--- a/crates/moqtail-core/tests/pipeline.rs
+++ b/crates/moqtail-core/tests/pipeline.rs
@@ -1,4 +1,4 @@
-use moqtail_core::{compile, Matcher, Message};
+use moqtail_core::{ast::Stage, compile, Matcher, Message};
 use serde_json::json;
 use std::collections::HashMap;
 
@@ -79,4 +79,13 @@ fn sum_missing_field() {
         payload: Some(json!({"other": 10})),
     };
     assert_eq!(m.process(&msg), None);
+}
+
+#[test]
+fn window_minutes_and_hours_parse() {
+    let minutes = compile("/sensor |> window(5m)").unwrap();
+    assert!(matches!(minutes.stages.as_slice(), [Stage::Window(300)]));
+
+    let hours = compile("/sensor |> window(1h)").unwrap();
+    assert!(matches!(hours.stages.as_slice(), [Stage::Window(3600)]));
 }

--- a/docs/src/pipeline_stages.md
+++ b/docs/src/pipeline_stages.md
@@ -4,7 +4,8 @@ Selectors can transform and aggregate matched messages using a Unix-like pipelin
 
 ## `window(duration)`
 
-Groups messages into tumbling time windows. The duration is specified in seconds.
+Groups messages into tumbling time windows. Specify the duration as a number
+followed by a unit suffix: `s` for seconds, `m` for minutes, or `h` for hours.
 
 ```bash
 $ moqtail sub "//sensor |> window(60s)"


### PR DESCRIPTION
## Summary
- expand the selector grammar so window durations accept second, minute, and hour suffixes
- convert parsed window durations to seconds before constructing Stage::Window
- document and test the new duration units

## Testing
- cargo test -p moqtail-core

------
https://chatgpt.com/codex/tasks/task_e_68d82c1d14ac8328bf50764cd19f22ba