### PR TITLE
Fix header predicate coercion and duration parsing

### DIFF
--- a/crates/moqtail-core/src/matcher.rs
+++ b/crates/moqtail-core/src/matcher.rs
@@ -67,7 +67,11 @@ impl Matcher {
     }
 
     pub fn matches(&self, msg: &Message) -> bool {
-        let segments: Vec<&str> = msg.topic.split('/').collect();
+        let segments: Vec<&str> = if msg.topic.is_empty() {
+            Vec::new()
+        } else {
+            msg.topic.split('/').collect()
+        };
         Self::match_steps(&self.selector.steps, &segments, msg)
     }
 
@@ -285,12 +289,17 @@ impl Matcher {
                     Some(v) => v.as_ref(),
                     None => return false,
                 };
-                if let Ok(num) = hv.parse::<f64>() {
-                    Value::Number(num)
-                } else if hv == "true" || hv == "false" {
-                    Value::Bool(hv == "true")
-                } else {
-                    Value::Str(hv.to_string())
+                match &pred.value {
+                    Value::Number(_) => match hv.parse::<f64>() {
+                        Ok(num) => Value::Number(num),
+                        Err(_) => return false,
+                    },
+                    Value::Bool(_) => match hv {
+                        "true" => Value::Bool(true),
+                        "false" => Value::Bool(false),
+                        _ => return false,
+                    },
+                    Value::Str(_) => Value::Str(hv.to_string()),
                 }
             }
             Field::Json(ref path) => {

--- a/crates/moqtail-core/src/parser.rs
+++ b/crates/moqtail-core/src/parser.rs
@@ -187,17 +187,22 @@ fn parse_stage(pair: pest::iterators::Pair<Rule>) -> Result<Stage, Error> {
     match name {
         "window" => {
             let a = arg.ok_or(Error::WindowRequiresDuration)?;
-            let mut ai = a.into_inner();
-            let num_pair = ai.next().ok_or(Error::WindowRequiresDuration)?;
-            let num = num_pair.as_str().parse::<u64>()?;
-            let unit_pair = ai.next().ok_or(Error::WindowRequiresDuration)?;
-            let seconds = match unit_pair.as_str() {
+            if a.as_rule() != Rule::duration {
+                return Err(Error::WindowRequiresDuration);
+            }
+            let text = a.as_str();
+            if text.len() < 2 {
+                return Err(Error::WindowRequiresDuration);
+            }
+            let (num_part, unit_part) = text.split_at(text.len() - 1);
+            let num = num_part.parse::<u64>()?;
+            let seconds = match unit_part {
                 "s" => num,
                 "m" => num.checked_mul(60).ok_or(Error::WindowRequiresDuration)?,
                 "h" => num.checked_mul(3600).ok_or(Error::WindowRequiresDuration)?,
-                _ => unreachable!(),
+                _ => return Err(Error::WindowRequiresDuration),
             };
-            Ok(Stage::Window(seconds))
+            Ok(Stage::Window(Duration::from_secs(seconds)))
         }
         "sum" => {
             let a = arg.ok_or(Error::SumRequiresField)?;

--- a/crates/moqtail-core/src/selector.pest
+++ b/crates/moqtail-core/src/selector.pest
@@ -34,4 +34,4 @@ stage = { pipe ~ function }
 pipe = _{ "|>" }
 function = { ident ~ "(" ~ func_arg? ~ ")" }
 func_arg = _{ duration | function | field }
-duration = { number ~ "s" }
+duration = { number ~ ("s" | "m" | "h") }

--- a/crates/moqtail-core/tests/pipeline.rs
+++ b/crates/moqtail-core/tests/pipeline.rs
@@ -91,7 +91,7 @@ fn sum_pipeline_large_unsigned() {
         headers,
         payload: Some(json!({"value": u64::MAX})),
     };
-    assert_eq!(m.process(&msg), Some(u64::MAX as f64));
+    assert_eq!(m.process(&msg, Instant::now()), Some(u64::MAX as f64));
 }
 
 #[test]
@@ -141,10 +141,16 @@ fn sum_missing_field() {
 #[test]
 fn window_minutes_and_hours_parse() {
     let minutes = compile("/sensor |> window(5m)").unwrap();
-    assert!(matches!(minutes.stages.as_slice(), [Stage::Window(300)]));
+    assert_eq!(
+        minutes.stages.as_slice(),
+        &[Stage::Window(Duration::from_secs(300))]
+    );
 
     let hours = compile("/sensor |> window(1h)").unwrap();
-    assert!(matches!(hours.stages.as_slice(), [Stage::Window(3600)]));
+    assert_eq!(
+        hours.stages.as_slice(),
+        &[Stage::Window(Duration::from_secs(3600))]
+    );
 }
 
 #[test]

--- a/crates/moqtail-core/tests/predicate.rs
+++ b/crates/moqtail-core/tests/predicate.rs
@@ -59,3 +59,27 @@ fn json_predicate_missing_field() {
     let err = compile("/foo[json$>1]").unwrap_err();
     assert!(matches!(err, Error::MissingField));
 }
+
+#[test]
+fn header_string_predicate_matches_numeric_text() {
+    let sel = compile("/msg[tag=\"123\"]").unwrap();
+    let msg = Message {
+        topic: "",
+        headers: HashMap::from([(Cow::Borrowed("tag"), Cow::Borrowed("123"))]),
+        payload: None,
+    };
+    let matcher = Matcher::new(sel);
+    assert!(matcher.matches(&msg));
+}
+
+#[test]
+fn header_string_predicate_matches_boolean_text() {
+    let sel = compile("/msg[flag=\"true\"]").unwrap();
+    let msg = Message {
+        topic: "",
+        headers: HashMap::from([(Cow::Borrowed("flag"), Cow::Borrowed("true"))]),
+        payload: None,
+    };
+    let matcher = Matcher::new(sel);
+    assert!(matcher.matches(&msg));
+}


### PR DESCRIPTION
## Summary
- adjust header predicate matching to coerce values based on the predicate variant and support empty topics
- parse window durations as `Duration`, recognizing seconds, minutes, and hours
- add regression tests for header string predicates and update pipeline duration expectations

## Testing
- cargo test -p moqtail-core

------
https://chatgpt.com/codex/tasks/task_e_69020d9617ac83288f813ce0e6a77871