### PR TITLE
Reject count arguments in parser

### DIFF
--- a/crates/moqtail-core/src/parser.rs
+++ b/crates/moqtail-core/src/parser.rs
@@ -45,6 +45,8 @@ pub enum Error {
     SumRequiresField,
     #[error("avg requires field")]
     AvgRequiresField,
+    #[error("count does not accept arguments")]
+    CountDoesNotAcceptArguments,
     #[error("unknown function {0}")]
     UnknownFunction(String),
 }
@@ -187,17 +189,7 @@ fn parse_stage(pair: pest::iterators::Pair<Rule>) -> Result<Stage, Error> {
     match name {
         "window" => {
             let a = arg.ok_or(Error::WindowRequiresDuration)?;
-            let mut ai = a.into_inner();
-            let num_pair = ai.next().ok_or(Error::WindowRequiresDuration)?;
-            let num = num_pair.as_str().parse::<u64>()?;
-            let unit_pair = ai.next().ok_or(Error::WindowRequiresDuration)?;
-            let seconds = match unit_pair.as_str() {
-                "s" => num,
-                "m" => num.checked_mul(60).ok_or(Error::WindowRequiresDuration)?,
-                "h" => num.checked_mul(3600).ok_or(Error::WindowRequiresDuration)?,
-                _ => unreachable!(),
-            };
-            Ok(Stage::Window(seconds))
+            Ok(Stage::Window(parse_duration(a)?))
         }
         "sum" => {
             let a = arg.ok_or(Error::SumRequiresField)?;
@@ -215,7 +207,26 @@ fn parse_stage(pair: pest::iterators::Pair<Rule>) -> Result<Stage, Error> {
             let field_inner = a.into_inner().next().ok_or(Error::AvgRequiresField)?;
             Ok(Stage::Avg(parse_field(field_inner)?))
         }
-        "count" => Ok(Stage::Count),
+        "count" => match arg {
+            Some(_) => Err(Error::CountDoesNotAcceptArguments),
+            None => Ok(Stage::Count),
+        },
         _ => Err(Error::UnknownFunction(name.to_string())),
     }
+}
+
+fn parse_duration(pair: pest::iterators::Pair<Rule>) -> Result<Duration, Error> {
+    let text = pair.as_str();
+    if text.len() < 2 {
+        return Err(Error::WindowRequiresDuration);
+    }
+    let (value, unit) = text.split_at(text.len() - 1);
+    let num = value.parse::<u64>()?;
+    let seconds = match unit {
+        "s" => num,
+        "m" => num.checked_mul(60).ok_or(Error::WindowRequiresDuration)?,
+        "h" => num.checked_mul(3600).ok_or(Error::WindowRequiresDuration)?,
+        _ => return Err(Error::WindowRequiresDuration),
+    };
+    Ok(Duration::from_secs(seconds))
 }

--- a/crates/moqtail-core/src/selector.pest
+++ b/crates/moqtail-core/src/selector.pest
@@ -34,4 +34,4 @@ stage = { pipe ~ function }
 pipe = _{ "|>" }
 function = { ident ~ "(" ~ func_arg? ~ ")" }
 func_arg = _{ duration | function | field }
-duration = { number ~ "s" }
+duration = { number ~ ("s" | "m" | "h") }

--- a/crates/moqtail-core/tests/pipeline.rs
+++ b/crates/moqtail-core/tests/pipeline.rs
@@ -1,4 +1,4 @@
-use moqtail_core::{ast::Stage, compile, Matcher, Message};
+use moqtail_core::{ast::Stage, compile, Error, Matcher, Message};
 use serde_json::json;
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
@@ -85,13 +85,14 @@ fn sum_pipeline_large_unsigned() {
     let mut m = Matcher::new(sel);
 
     let headers = HashMap::new();
+    let start = Instant::now();
 
     let msg = Message {
         topic: "sensor",
         headers,
         payload: Some(json!({"value": u64::MAX})),
     };
-    assert_eq!(m.process(&msg), Some(u64::MAX as f64));
+    assert_eq!(m.process(&msg, start), Some(u64::MAX as f64));
 }
 
 #[test]
@@ -141,10 +142,16 @@ fn sum_missing_field() {
 #[test]
 fn window_minutes_and_hours_parse() {
     let minutes = compile("/sensor |> window(5m)").unwrap();
-    assert!(matches!(minutes.stages.as_slice(), [Stage::Window(300)]));
+    assert_eq!(
+        minutes.stages.as_slice(),
+        [Stage::Window(Duration::from_secs(300))]
+    );
 
     let hours = compile("/sensor |> window(1h)").unwrap();
-    assert!(matches!(hours.stages.as_slice(), [Stage::Window(3600)]));
+    assert_eq!(
+        hours.stages.as_slice(),
+        [Stage::Window(Duration::from_secs(3600))]
+    );
 }
 
 #[test]
@@ -160,5 +167,13 @@ fn avg_requires_field_argument() {
     assert!(matches!(
         compile("/foo |> avg(window(5s))"),
         Err(moqtail_core::Error::AvgRequiresField)
+    ));
+}
+
+#[test]
+fn count_rejects_arguments() {
+    assert!(matches!(
+        compile("/foo |> count(temp)"),
+        Err(Error::CountDoesNotAcceptArguments)
     ));
 }


### PR DESCRIPTION
## Summary
- add a dedicated parser error when count receives an argument
- parse window durations into `Duration` values and accept minute/hour suffixes
- expand pipeline tests to cover the new error and updated duration handling

## Testing
- cargo test -p moqtail-core --test pipeline

------
https://chatgpt.com/codex/tasks/task_e_69020d94b1108328a75e25e3d2d3739e