### PR TITLE
Simplify window duration parsing and add focused tests

### DIFF
--- a/crates/moqtail-core/src/parser.rs
+++ b/crates/moqtail-core/src/parser.rs
@@ -190,42 +190,27 @@ fn parse_stage(pair: pest::iterators::Pair<Rule>) -> Result<Stage, Error> {
             if a.as_rule() != Rule::duration {
                 return Err(Error::WindowRequiresDuration);
             }
-            let text = a.as_str();
-            if text.len() < 2 {
+            let mut duration_parts = a.into_inner();
+            let value = duration_parts.next().ok_or(Error::WindowRequiresDuration)?;
+            let unit = duration_parts.next().ok_or(Error::WindowRequiresDuration)?;
+            if value.as_rule() != Rule::number || unit.as_rule() != Rule::unit {
                 return Err(Error::WindowRequiresDuration);
             }
-            let (num_part, unit_part) = text.split_at(text.len() - 1);
-            let num = num_part.parse::<u64>()?;
-            let seconds = match unit_part {
-            let duration_text = a.as_str().trim();
-            if duration_text.len() < 2 {
+            if duration_parts.next().is_some() {
                 return Err(Error::WindowRequiresDuration);
             }
-            let (value, unit) = duration_text.split_at(duration_text.len() - 1);
-            let num = value.parse::<u64>()?;
-            let seconds = match unit {
-            if a.as_rule() != Rule::duration {
-                return Err(Error::WindowRequiresDuration);
-            }
-            let mut ai = a.into_inner();
-            let num_pair = ai.next().ok_or(Error::WindowRequiresDuration)?;
-            if num_pair.as_rule() != Rule::number {
-                return Err(Error::WindowRequiresDuration);
-            }
-            let num = num_pair.as_str().parse::<u64>()?;
-            let unit_pair = ai.next().ok_or(Error::WindowRequiresDuration)?;
-            if unit_pair.as_rule() != Rule::unit {
-                return Err(Error::WindowRequiresDuration);
-            }
-            let seconds = match unit_pair.as_str() {
-                "s" => num,
-                "m" => num.checked_mul(60).ok_or(Error::WindowRequiresDuration)?,
-                "h" => num.checked_mul(3600).ok_or(Error::WindowRequiresDuration)?,
+
+            let amount = value.as_str().parse::<u64>()?;
+            let seconds = match unit.as_str() {
+                "s" => amount,
+                "m" => amount
+                    .checked_mul(60)
+                    .ok_or(Error::WindowRequiresDuration)?,
+                "h" => amount
+                    .checked_mul(3600)
+                    .ok_or(Error::WindowRequiresDuration)?,
                 _ => return Err(Error::WindowRequiresDuration),
             };
-            if ai.next().is_some() {
-                return Err(Error::WindowRequiresDuration);
-            }
             Ok(Stage::Window(Duration::from_secs(seconds)))
         }
         "sum" => {

--- a/crates/moqtail-core/tests/pipeline.rs
+++ b/crates/moqtail-core/tests/pipeline.rs
@@ -85,7 +85,6 @@ fn sum_pipeline_large_unsigned() {
     let mut m = Matcher::new(sel);
 
     let headers = HashMap::new();
-    let start = Instant::now();
 
     let msg = Message {
         topic: "sensor",
@@ -140,37 +139,33 @@ fn sum_missing_field() {
 }
 
 #[test]
-fn window_minutes_and_hours_parse() {
-    let minutes = compile("/sensor |> window(5m)").unwrap();
+fn window_parses_seconds_minutes_and_hours() {
+    let seconds = compile("/sensor |> window(5s)").unwrap();
+    assert_eq!(
+        seconds.stages.as_slice(),
+        &[Stage::Window(Duration::from_secs(5))]
+    );
+
+    let minutes = compile("/sensor |> window(2m)").unwrap();
     assert_eq!(
         minutes.stages.as_slice(),
-        &[Stage::Window(Duration::from_secs(300))]
+        &[Stage::Window(Duration::from_secs(120))]
     );
 
     let hours = compile("/sensor |> window(1h)").unwrap();
     assert_eq!(
         hours.stages.as_slice(),
         &[Stage::Window(Duration::from_secs(3600))]
-    assert!(matches!(
-        minutes.stages.as_slice(),
-        [Stage::Window(d)] if *d == Duration::from_secs(300)
-    ));
-
-    let hours = compile("/sensor |> window(1h)").unwrap();
-    assert!(matches!(
-        hours.stages.as_slice(),
-        [Stage::Window(d)] if *d == Duration::from_secs(3600)
-    ));
-    assert_eq!(
-        minutes.stages.as_slice(),
-        [Stage::Window(Duration::from_secs(300))]
     );
+}
 
-    let hours = compile("/sensor |> window(1h)").unwrap();
-    assert_eq!(
-        hours.stages.as_slice(),
-        [Stage::Window(Duration::from_secs(3600))]
-    );
+#[test]
+fn window_rejects_malformed_unit_and_missing_argument() {
+    assert!(compile("/sensor |> window(5x)").is_err());
+    assert!(matches!(
+        compile("/sensor |> window()"),
+        Err(moqtail_core::Error::WindowRequiresDuration)
+    ));
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- Remove duplicated and interleaved parsing fragments in the `window` branch to make the logic easier to read and maintain.
- Ensure robust validation and overflow-safe unit conversion for duration arguments passed to `window(...)`.

### Description
- Rewrote the `window` arm in `parse_stage` to follow a single parsing path that first validates `Rule::duration` and then extracts parts via `into_inner()` once. 
- Enforced that the duration contains exactly a `number` and a `unit`, parsed the number once with `parse::<u64>()`, and converted `s`/`m`/`h` to seconds using `checked_mul` for overflow checks. 
- Returns `Stage::Window(Duration::from_secs(seconds))` for valid inputs and returns `Error::WindowRequiresDuration` on malformed input. 
- Added focused parser tests in `tests/pipeline.rs` to cover valid forms `window(5s)`, `window(2m)`, `window(1h)` and invalid cases `window(5x)` and `window()`.

### Testing
- Ran `cargo test -p moqtail-core --test pipeline` and the pipeline test-suite passed (all tests ok).
- Ran full crate tests with `cargo test -p moqtail-core` and all unit tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d17b3d855083288a98de9bc112a569)