### PR TITLE
Refactor CLI credential tests and redact password values in connection errors

### DIFF
--- a/crates/moqtail-cli/src/main.rs
+++ b/crates/moqtail-cli/src/main.rs
@@ -85,7 +85,7 @@ pub(crate) fn run_sub(cmd: SubArgs) -> Result<(), String> {
 
     let (client, mut connection) = Client::new(mqttoptions, 10);
     if let Err(e) = client.subscribe(selector.to_string(), QoS::AtMostOnce) {
-        return Err(format!("Connection error: {e}"));
+        return Err(connection_error(e, cmd.password.as_deref()));
     }
     for event in connection.iter() {
         match event {
@@ -93,10 +93,22 @@ pub(crate) fn run_sub(cmd: SubArgs) -> Result<(), String> {
                 println!("{}: {}", p.topic, String::from_utf8_lossy(&p.payload));
             }
             Ok(_) => {}
-            Err(e) => return Err(format!("Connection error: {e}")),
+            Err(e) => return Err(connection_error(e, cmd.password.as_deref())),
         }
     }
     Ok(())
+}
+
+fn connection_error(error: impl std::fmt::Display, password: Option<&str>) -> String {
+    let raw = format!("Connection error: {error}");
+    redact_password(&raw, password)
+}
+
+fn redact_password(message: &str, password: Option<&str>) -> String {
+    match password {
+        Some(password) if !password.is_empty() => message.replace(password, "[REDACTED]"),
+        _ => message.to_string(),
+    }
 }
 
 fn main() {
@@ -134,9 +146,7 @@ mod tests {
             tls: false,
         };
         let opts = opts_from(cmd);
-        let dbg = format!("{:?}", opts);
-        assert!(dbg.contains("user"));
-        assert!(dbg.contains("pass"));
+        assert_eq!(opts.credentials(), Some(("user".to_owned(), "pass".to_owned())));
     }
 
     #[test]
@@ -151,8 +161,8 @@ mod tests {
             #[cfg(feature = "tls")]
             tls: false,
         };
-        let dbg = format!("{:?}", opts_from(cmd));
-        assert!(dbg.contains("user"));
+        let opts = opts_from(cmd);
+        assert_eq!(opts.credentials(), Some(("user".to_owned(), "".to_owned())));
 
         let cmd = SubArgs {
             query: "/foo".into(),
@@ -164,8 +174,19 @@ mod tests {
             #[cfg(feature = "tls")]
             tls: false,
         };
-        let dbg = format!("{:?}", opts_from(cmd));
-        assert!(dbg.contains("pass"));
+        let opts = opts_from(cmd);
+        assert_eq!(opts.credentials(), Some(("".to_owned(), "pass".to_owned())));
+    }
+
+    #[test]
+    fn connection_errors_redact_password() {
+        let password = "super-secret";
+        let err = connection_error(
+            format!("auth failed for password={password} at broker"),
+            Some(password),
+        );
+        assert!(err.contains("[REDACTED]"));
+        assert!(!err.contains(password));
     }
 
     #[cfg(feature = "tls")]


### PR DESCRIPTION
### Motivation
- Tests were asserting secret visibility by inspecting `Debug` output of `MqttOptions`, which risks encouraging or relying on accidental password leaks.  
- User-facing connection error messages could include raw password substrings when formatted, creating a potential information leak in logs or stderr.  
- Add a regression check to ensure errors emitted to users do not contain the provided `--password` content.

### Description
- Replace `Debug`-string assertions in tests with behavioral checks that call `MqttOptions::credentials()` to verify username/password pairs.  
- Introduce `connection_error` and `redact_password` helpers and use them when returning connection errors from `run_sub`, which redact any occurrences of the provided password.  
- Update `run_sub` to call `connection_error(..., cmd.password.as_deref())` for all connection failure paths.  
- Add `connection_errors_redact_password` unit test to assert that redaction occurs and that the raw password is not present in the returned message.

### Testing
- Attempted to run `cargo test -p moqtail-cli`, but the test run was blocked by a pre-existing compile error in `crates/moqtail-core/src/parser.rs` (unclosed delimiter) unrelated to these changes, so CLI tests did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d17b430b208328880ed3b85cada6cc)