### PR TITLE
Reject arguments to count stage

### DIFF
--- a/crates/moqtail-core/src/parser.rs
+++ b/crates/moqtail-core/src/parser.rs
@@ -45,6 +45,8 @@ pub enum Error {
     SumRequiresField,
     #[error("avg requires field")]
     AvgRequiresField,
+    #[error("count takes no arguments")]
+    CountTakesNoArguments,
     #[error("unknown function {0}")]
     UnknownFunction(String),
 }
@@ -229,7 +231,12 @@ fn parse_stage(pair: pest::iterators::Pair<Rule>) -> Result<Stage, Error> {
             let field_inner = a.into_inner().next().ok_or(Error::AvgRequiresField)?;
             Ok(Stage::Avg(parse_field(field_inner)?))
         }
-        "count" => Ok(Stage::Count),
+        "count" => {
+            if arg.is_some() {
+                return Err(Error::CountTakesNoArguments);
+            }
+            Ok(Stage::Count)
+        }
         _ => Err(Error::UnknownFunction(name.to_string())),
     }
 }

--- a/crates/moqtail-core/tests/pipeline.rs
+++ b/crates/moqtail-core/tests/pipeline.rs
@@ -1,4 +1,4 @@
-use moqtail_core::{ast::Stage, compile, Matcher, Message};
+use moqtail_core::{ast::Stage, compile, Error, Matcher, Message};
 use serde_json::json;
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
@@ -123,6 +123,18 @@ fn count_pipeline() {
     };
     // Only the two most recent events fall in the trailing 60s window.
     assert_eq!(m.process(&msg3, start + Duration::from_secs(90)), Some(2.0));
+}
+
+#[test]
+fn count_rejects_arguments() {
+    assert!(matches!(
+        compile("/sensor |> count(json$.value)"),
+        Err(Error::CountTakesNoArguments)
+    ));
+    assert!(matches!(
+        compile("/sensor |> count(window(5s))"),
+        Err(Error::CountTakesNoArguments)
+    ));
 }
 
 #[test]

--- a/crates/moqtail-core/tests/selector.rs
+++ b/crates/moqtail-core/tests/selector.rs
@@ -1,5 +1,5 @@
 use moqtail_core::{
-    ast::{Axis, Field, Operator, Predicate, Segment, Selector, Step, Value},
+    ast::{Axis, Field, Operator, Predicate, Segment, Selector, Stage, Step, Value},
     compile, Error,
 };
 
@@ -155,4 +155,18 @@ fn parse_negative_fractional_number() {
 fn error_on_malformed_json_prefix() {
     let err = compile("/foo[json.temp>30]").unwrap_err();
     assert!(matches!(err, Error::MissingField));
+}
+
+#[test]
+fn selector_display_keeps_count_parentheses() {
+    let sel = Selector {
+        steps: vec![Step {
+            axis: Axis::Child,
+            segment: Segment::Literal("sensor".into()),
+            predicates: vec![],
+        }],
+        stages: vec![Stage::Count],
+    };
+
+    assert_eq!(sel.to_string(), "/sensor |> count()");
 }


### PR DESCRIPTION
### Motivation
- The `count` aggregation should be a parameterless stage, so the parser must reject usages like `count(json$.value)` or `count(window(5s))` with a clear error.

### Description
- Added a new parser error variant `CountTakesNoArguments` in `crates/moqtail-core/src/parser.rs` to represent the specific misuse of `count` with arguments.
- Updated `parse_stage` in `crates/moqtail-core/src/parser.rs` so the `"count"` arm returns `Err(Error::CountTakesNoArguments)` when an argument is present and only returns `Ok(Stage::Count)` for bare `count()` calls.
- Added a regression test `count_rejects_arguments` in `crates/moqtail-core/tests/pipeline.rs` that asserts `compile("/sensor |> count(json$.value)")` and `compile("/sensor |> count(window(5s))")` both error with `CountTakesNoArguments`.
- Added a display regression `selector_display_keeps_count_parentheses` in `crates/moqtail-core/tests/selector.rs` asserting `Selector::to_string()` still emits `"/sensor |> count()"` for a valid count stage.

### Testing
- Ran `cargo test -p moqtail-core` which completed but a pre-existing, unrelated library test `matcher::tests::values_outside_hybrid_tolerance_are_not_equal` failed; this failure is not caused by the parser changes.
- Ran the focused pipeline test with `cargo test -p moqtail-core --test pipeline count_rejects_arguments` which passed.
- Ran the focused selector test with `cargo test -p moqtail-core --test selector selector_display_keeps_count_parentheses` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feb0888f148328925bd851211facc7)