### PR TITLE
Harden plugin FFI initialization

### DIFF
--- a/plugins/emqx/src/lib.rs
+++ b/plugins/emqx/src/lib.rs
@@ -17,8 +17,16 @@ pub struct EmqxMessage {
 type HookFn = extern "C" fn(*mut EmqxMessage, *mut c_void) -> c_int;
 
 extern "C" {
-    fn emqx_extension_register_hook(name: *const c_char, cb: Option<HookFn>, data: *mut c_void) -> c_int;
-    fn emqx_extension_unregister_hook(name: *const c_char, cb: Option<HookFn>, data: *mut c_void) -> c_int;
+    fn emqx_extension_register_hook(
+        name: *const c_char,
+        cb: Option<HookFn>,
+        data: *mut c_void,
+    ) -> c_int;
+    fn emqx_extension_unregister_hook(
+        name: *const c_char,
+        cb: Option<HookFn>,
+        data: *mut c_void,
+    ) -> c_int;
 }
 
 const MESSAGE_HOOK: &[u8] = b"message_publish\0";
@@ -28,6 +36,10 @@ pub struct PluginContext {
 }
 
 extern "C" fn on_message(msg: *mut EmqxMessage, userdata: *mut c_void) -> c_int {
+    if userdata.is_null() {
+        return 1;
+    }
+
     unsafe {
         let ctx = &*(userdata as *mut PluginContext);
         if msg.is_null() || (*msg).topic.is_null() {
@@ -53,8 +65,18 @@ extern "C" fn on_message(msg: *mut EmqxMessage, userdata: *mut c_void) -> c_int 
 
 /// Called by EMQX when the plugin is loaded.
 #[no_mangle]
-pub unsafe extern "C" fn moqtail_init(selectors: *const *const c_char, count: usize) -> *mut c_void {
-    let slice = std::slice::from_raw_parts(selectors, count);
+pub unsafe extern "C" fn moqtail_init(
+    selectors: *const *const c_char,
+    count: usize,
+) -> *mut c_void {
+    let slice = if count == 0 {
+        &[]
+    } else {
+        if selectors.is_null() {
+            return std::ptr::null_mut();
+        }
+        std::slice::from_raw_parts(selectors, count)
+    };
     let mut matchers = Vec::new();
     for &ptr in slice {
         if ptr.is_null() {
@@ -72,7 +94,11 @@ pub unsafe extern "C" fn moqtail_init(selectors: *const *const c_char, count: us
 
     let ctx = Box::new(PluginContext { matchers });
     let ctx_ptr = Box::into_raw(ctx) as *mut c_void;
-    emqx_extension_register_hook(MESSAGE_HOOK.as_ptr() as *const c_char, Some(on_message), ctx_ptr);
+    emqx_extension_register_hook(
+        MESSAGE_HOOK.as_ptr() as *const c_char,
+        Some(on_message),
+        ctx_ptr,
+    );
     ctx_ptr
 }
 
@@ -82,7 +108,11 @@ pub unsafe extern "C" fn moqtail_deinit(ctx: *mut c_void) {
     if ctx.is_null() {
         return;
     }
-    emqx_extension_unregister_hook(MESSAGE_HOOK.as_ptr() as *const c_char, Some(on_message), ctx);
+    emqx_extension_unregister_hook(
+        MESSAGE_HOOK.as_ptr() as *const c_char,
+        Some(on_message),
+        ctx,
+    );
     drop(Box::from_raw(ctx as *mut PluginContext));
 }
 
@@ -117,15 +147,45 @@ mod tests {
     }
 
     #[test]
+    fn on_message_rejects_null_userdata() {
+        let topic = CString::new("foo/bar").unwrap();
+        let mut msg = EmqxMessage {
+            topic: topic.as_ptr(),
+        };
+
+        assert_eq!(on_message(&mut msg as *mut _, std::ptr::null_mut()), 1);
+    }
+
+    #[test]
+    fn init_accepts_zero_selectors_and_rejects_missing_selectors() {
+        unsafe {
+            REGISTERED = None;
+            let ctx = moqtail_init(std::ptr::null(), 0);
+            assert!(!ctx.is_null());
+            let registered = REGISTERED;
+            assert!(registered.is_some());
+            moqtail_deinit(ctx);
+
+            REGISTERED = None;
+            let ctx = moqtail_init(std::ptr::null(), 1);
+            assert!(ctx.is_null());
+            let registered = REGISTERED;
+            assert!(registered.is_none());
+        }
+    }
+
+    #[test]
     fn filter_logic() {
         unsafe {
-            let sel = CString::new("/foo/+" ).unwrap();
+            let sel = CString::new("/foo/+").unwrap();
             let arr = [sel.as_ptr()];
             let ctx = moqtail_init(arr.as_ptr(), arr.len());
             let (cb, data) = REGISTERED.expect("hook registered");
 
             let topic1 = CString::new("foo/bar").unwrap();
-            let mut msg = EmqxMessage { topic: topic1.as_ptr() };
+            let mut msg = EmqxMessage {
+                topic: topic1.as_ptr(),
+            };
             assert_eq!(cb(&mut msg as *mut _, data), 0);
 
             let topic2 = CString::new("baz/qux").unwrap();
@@ -133,7 +193,8 @@ mod tests {
             assert_eq!(cb(&mut msg as *mut _, data), 1);
 
             moqtail_deinit(ctx);
-            assert!(REGISTERED.is_none());
+            let registered = REGISTERED;
+            assert!(registered.is_none());
         }
     }
 }

--- a/plugins/mosquitto/src/lib.rs
+++ b/plugins/mosquitto/src/lib.rs
@@ -29,6 +29,10 @@ pub struct PluginContext {
 }
 
 extern "C" fn on_message(_: c_int, event_data: *mut c_void, userdata: *mut c_void) -> c_int {
+    if userdata.is_null() || event_data.is_null() {
+        return MOSQ_ERR_PLUGIN_DEFER;
+    }
+
     unsafe {
         let ctx = &*(userdata as *mut PluginContext);
         let msg = &*(event_data as *mut mosquitto_evt_message);
@@ -80,7 +84,18 @@ pub unsafe extern "C" fn mosquitto_plugin_init(
     options: *mut mosquitto_opt,
     option_count: c_int,
 ) -> c_int {
-    let slice = std::slice::from_raw_parts(options, option_count as usize);
+    if userdata.is_null() || option_count < 0 {
+        return MOSQ_ERR_PLUGIN_DEFER;
+    }
+
+    let slice = if option_count == 0 {
+        &[]
+    } else {
+        if options.is_null() {
+            return MOSQ_ERR_PLUGIN_DEFER;
+        }
+        std::slice::from_raw_parts(options, option_count as usize)
+    };
     let mut matchers = Vec::new();
 
     for opt in slice.iter() {
@@ -99,15 +114,21 @@ pub unsafe extern "C" fn mosquitto_plugin_init(
 
     let ctx = Box::new(PluginContext { matchers });
     let ctx_ptr = Box::into_raw(ctx) as *mut c_void;
-    *userdata = ctx_ptr;
 
-    mosquitto_callback_register(
+    let rc = mosquitto_callback_register(
         identifier as *mut mosquitto_plugin_id_t,
         MOSQ_EVT_MESSAGE,
         Some(on_message),
         std::ptr::null(),
         ctx_ptr,
-    )
+    );
+    if rc != MOSQ_ERR_SUCCESS {
+        drop(Box::from_raw(ctx_ptr as *mut PluginContext));
+        return rc;
+    }
+
+    *userdata = ctx_ptr;
+    MOSQ_ERR_SUCCESS
 }
 
 /// Called when the plugin is unloaded.
@@ -141,6 +162,7 @@ mod tests {
         extern "C" fn(c_int, *mut c_void, *mut c_void) -> c_int,
         *mut c_void,
     )> = None;
+    pub static mut REGISTER_RC: c_int = MOSQ_ERR_SUCCESS;
 
     #[no_mangle]
     unsafe extern "C" fn mosquitto_callback_register(
@@ -150,10 +172,13 @@ mod tests {
         _event_data: *const c_void,
         userdata: *mut c_void,
     ) -> c_int {
-        if let Some(f) = cb_func {
-            REGISTERED = Some((f, userdata));
+        let rc = REGISTER_RC;
+        if rc == MOSQ_ERR_SUCCESS {
+            if let Some(f) = cb_func {
+                REGISTERED = Some((f, userdata));
+            }
         }
-        MOSQ_ERR_SUCCESS
+        rc
     }
 
     #[no_mangle]
@@ -168,8 +193,107 @@ mod tests {
     }
 
     #[test]
+    fn on_message_rejects_null_callback_data() {
+        let topic = CString::new("foo/bar").unwrap();
+        let mut msg = mosquitto_evt_message {
+            future: std::ptr::null_mut(),
+            client: std::ptr::null_mut(),
+            topic: topic.as_ptr() as *mut c_char,
+            payload: std::ptr::null_mut(),
+            properties: std::ptr::null_mut(),
+            reason_string: std::ptr::null_mut(),
+            payloadlen: 0,
+            qos: 0,
+            reason_code: 0,
+            retain: false,
+            future2: [std::ptr::null_mut(); 4],
+        };
+        let mut ctx = PluginContext {
+            matchers: Vec::new(),
+        };
+
+        assert_eq!(
+            on_message(
+                MOSQ_EVT_MESSAGE,
+                std::ptr::null_mut(),
+                &mut ctx as *mut _ as *mut c_void
+            ),
+            MOSQ_ERR_PLUGIN_DEFER
+        );
+        assert_eq!(
+            on_message(
+                MOSQ_EVT_MESSAGE,
+                &mut msg as *mut _ as *mut c_void,
+                std::ptr::null_mut(),
+            ),
+            MOSQ_ERR_PLUGIN_DEFER
+        );
+    }
+
+    #[test]
+    fn init_accepts_zero_options_and_rejects_invalid_inputs() {
+        unsafe {
+            REGISTERED = None;
+            REGISTER_RC = MOSQ_ERR_SUCCESS;
+            let mut userdata: *mut c_void = std::ptr::null_mut();
+
+            assert_eq!(
+                mosquitto_plugin_init(std::ptr::null_mut(), &mut userdata, std::ptr::null_mut(), 0,),
+                MOSQ_ERR_SUCCESS
+            );
+            assert!(!userdata.is_null());
+            let registered = REGISTERED;
+            assert!(registered.is_some());
+            mosquitto_plugin_cleanup(std::ptr::null_mut(), userdata, std::ptr::null_mut(), 0);
+
+            assert_eq!(
+                mosquitto_plugin_init(std::ptr::null_mut(), &mut userdata, std::ptr::null_mut(), 1),
+                MOSQ_ERR_PLUGIN_DEFER
+            );
+            assert_eq!(
+                mosquitto_plugin_init(
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                    0,
+                ),
+                MOSQ_ERR_PLUGIN_DEFER
+            );
+            assert_eq!(
+                mosquitto_plugin_init(
+                    std::ptr::null_mut(),
+                    &mut userdata,
+                    std::ptr::null_mut(),
+                    -1,
+                ),
+                MOSQ_ERR_PLUGIN_DEFER
+            );
+        }
+    }
+
+    #[test]
+    fn init_does_not_write_userdata_when_registration_fails() {
+        unsafe {
+            REGISTERED = None;
+            REGISTER_RC = MOSQ_ERR_PLUGIN_DEFER;
+            let mut userdata: *mut c_void = std::ptr::null_mut();
+
+            assert_eq!(
+                mosquitto_plugin_init(std::ptr::null_mut(), &mut userdata, std::ptr::null_mut(), 0),
+                MOSQ_ERR_PLUGIN_DEFER
+            );
+            assert!(userdata.is_null());
+            let registered = REGISTERED;
+            assert!(registered.is_none());
+
+            REGISTER_RC = MOSQ_ERR_SUCCESS;
+        }
+    }
+
+    #[test]
     fn filter_logic() {
         unsafe {
+            REGISTER_RC = MOSQ_ERR_SUCCESS;
             let key = CString::new("selector").unwrap();
             let val = CString::new("/foo/+").unwrap();
             let mut opt = mosquitto_opt {
@@ -223,7 +347,8 @@ mod tests {
             );
 
             mosquitto_plugin_cleanup(std::ptr::null_mut(), userdata, std::ptr::null_mut(), 0);
-            assert!(REGISTERED.is_none());
+            let registered = REGISTERED;
+            assert!(registered.is_none());
         }
     }
 }


### PR DESCRIPTION
### Motivation

- Harden FFI entry points and initialization paths to avoid undefined behavior from null pointer dereferences and invalid input passed by the broker/host.

### Description

- Add null checks in Mosquitto `on_message` to return `MOSQ_ERR_PLUGIN_DEFER` when `userdata` or `event_data` are null and avoid any pointer casts or dereferences.
- Harden `mosquitto_plugin_init` to reject null `userdata`, reject negative `option_count`, treat `option_count == 0` as an empty slice, and return an error when `options` is null with a non-zero count, and only write `*userdata` after successful callback registration while cleaning up the allocated context on failure.
- Add null check for `userdata` in EMQX `on_message` and make `moqtail_init` use an empty selector slice when `count == 0` while rejecting `selectors.is_null()` when `count > 0`.
- Add unit tests exercising null callback data and zero-option/zero-selector initialization paths and simulate registration failure for Mosquitto to ensure `userdata` is not written on failed registration.

### Testing

- Ran `cargo test --manifest-path plugins/mosquitto/Cargo.toml` and all Mosquitto tests passed (including new tests for null callback data, zero-options, and failed registration handling).
- Ran `cargo test --manifest-path plugins/emqx/Cargo.toml` and all EMQX tests passed (including new tests for null `userdata` and zero-selector initialization).
- Ran static/diff checks (`git diff --check` on modified plugin files) with no whitespace errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feb08c40a48328975db97c2c03c387)